### PR TITLE
Core Entity: fix typo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ out/
 
 ### VS Code ###
 .vscode/
+
+.floo
+
+.flooignore

--- a/core/src/main/java/kr/hs/entrydsm/husky/entities/applications/Application.java
+++ b/core/src/main/java/kr/hs/entrydsm/husky/entities/applications/Application.java
@@ -1,12 +1,12 @@
 package kr.hs.entrydsm.husky.entities.applications;
 
 import kr.hs.entrydsm.husky.entities.users.User;
-import lombok.Data;
+import lombok.Getter;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
 
-@Data
+@Getter
 @Entity
 @Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
 public abstract class Application {

--- a/core/src/main/java/kr/hs/entrydsm/husky/entities/applications/CalculatedScore.java
+++ b/core/src/main/java/kr/hs/entrydsm/husky/entities/applications/CalculatedScore.java
@@ -2,13 +2,13 @@ package kr.hs.entrydsm.husky.entities.applications;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.Entity;
 import java.math.BigDecimal;
 
-@Data
+@Getter
 @Builder
 @Entity
 @NoArgsConstructor

--- a/core/src/main/java/kr/hs/entrydsm/husky/entities/applications/GEDApplication.java
+++ b/core/src/main/java/kr/hs/entrydsm/husky/entities/applications/GEDApplication.java
@@ -1,14 +1,11 @@
 package kr.hs.entrydsm.husky.entities.applications;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
 
-@Data
+@Getter
 @Builder
 @Entity(name = "ged_application")
 @NoArgsConstructor

--- a/core/src/main/java/kr/hs/entrydsm/husky/entities/applications/GraduatedApplication.java
+++ b/core/src/main/java/kr/hs/entrydsm/husky/entities/applications/GraduatedApplication.java
@@ -1,12 +1,12 @@
 package kr.hs.entrydsm.husky.entities.applications;
 
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.Entity;
 
-@Data
+@Getter
 @Builder
 @Entity
 @NoArgsConstructor

--- a/core/src/main/java/kr/hs/entrydsm/husky/entities/applications/UnGraduatedApplication.java
+++ b/core/src/main/java/kr/hs/entrydsm/husky/entities/applications/UnGraduatedApplication.java
@@ -1,12 +1,12 @@
 package kr.hs.entrydsm.husky.entities.applications;
 
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.Entity;
 
-@Data
+@Getter
 @Builder
 @Entity(name = "ungraduated_application")
 @NoArgsConstructor

--- a/core/src/main/java/kr/hs/entrydsm/husky/entities/schools/School.java
+++ b/core/src/main/java/kr/hs/entrydsm/husky/entities/schools/School.java
@@ -1,15 +1,12 @@
 package kr.hs.entrydsm.husky.entities.schools;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 
-@Data
+@Getter
 @Builder
 @Entity
 @NoArgsConstructor

--- a/core/src/main/java/kr/hs/entrydsm/husky/entities/users/Status.java
+++ b/core/src/main/java/kr/hs/entrydsm/husky/entities/users/Status.java
@@ -38,7 +38,7 @@ public class Status {
     private LocalDateTime submittedAt;              // 최종 제출 시각
 
     @Column(length = 6)
-    private String examCore;
+    private String examCode;
 
     @OneToOne(cascade = CascadeType.ALL)
     @PrimaryKeyJoinColumn

--- a/core/src/main/java/kr/hs/entrydsm/husky/entities/users/Status.java
+++ b/core/src/main/java/kr/hs/entrydsm/husky/entities/users/Status.java
@@ -1,14 +1,11 @@
 package kr.hs.entrydsm.husky.entities.users;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
 
-@Data
+@Getter
 @Builder
 @Entity
 @NoArgsConstructor

--- a/core/src/main/java/kr/hs/entrydsm/husky/entities/users/User.java
+++ b/core/src/main/java/kr/hs/entrydsm/husky/entities/users/User.java
@@ -8,16 +8,13 @@ import kr.hs.entrydsm.husky.entities.users.enums.AdditionalType;
 import kr.hs.entrydsm.husky.entities.users.enums.ApplyType;
 import kr.hs.entrydsm.husky.entities.users.enums.GradeType;
 import kr.hs.entrydsm.husky.entities.users.enums.Sex;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
 import java.util.Date;
 
-@Data
+@Getter
 @Builder
 @Entity(name = "user")
 @NoArgsConstructor


### PR DESCRIPTION
# Entity 수정
## 목적
### 요약
- 오타 수정
- `@Data` 어노테이션 삭제
### 상세
- @Gaegul의 권고에 따라  `exam_core`를 `exam_code`로 수정함
- `@Data`와 `@Setter` 어노테이션 사용을 지양하자는 팀 내 분위기에 따라 `@Data` 어노테이션을 `@Getter`로 수정함
## 영향을 미치는 부분
- core 모듈을 참조하고 있는 모든 모듈


[[core-entity] 엔티티 수정](https://app.gitkraken.com/glo/card/b50495eb39c14e71912a9d974d1f075b)