### PR TITLE
Core entity school

### DIFF
--- a/core/src/main/java/kr/hs/entrydsm/husky/entities/schools/repositories/SchoolRepository.java
+++ b/core/src/main/java/kr/hs/entrydsm/husky/entities/schools/repositories/SchoolRepository.java
@@ -1,9 +1,8 @@
 package kr.hs.entrydsm.husky.entities.schools.repositories;
 
 import kr.hs.entrydsm.husky.entities.schools.School;
-import org.springframework.data.repository.CrudRepository;
-import org.springframework.stereotype.Repository;
+import org.springframework.data.jpa.repository.JpaRepository;
 
-@Repository
-public interface SchoolRepository extends CrudRepository<School, String> {
+public interface SchoolRepository extends JpaRepository<School, String> {
+
 }

--- a/core/src/main/java/kr/hs/entrydsm/husky/entities/schools/repositories/SchoolRepository.java
+++ b/core/src/main/java/kr/hs/entrydsm/husky/entities/schools/repositories/SchoolRepository.java
@@ -1,8 +1,11 @@
 package kr.hs.entrydsm.husky.entities.schools.repositories;
 
 import kr.hs.entrydsm.husky.entities.schools.School;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SchoolRepository extends JpaRepository<School, String> {
 
+    Page<School> findBySchoolFullNameContainsAndSchoolNameContains(String region, String name, Pageable pageable);
 }


### PR DESCRIPTION
# Core entity school
## 목적
### 요약
* school entity의 상위 객체를 JpaRepository로 변경.
* findBySchoolFullNameContainsAndSchoolNameContains 메서드 추가
### 상세
`school entity의 상위 객체를 JpaRepository로 변경`
기존 CrudRepository에서 **JpaRepository**로 상위 객체를 변경하였습니다. 이유는 크게 2가지가 있습니다.  

첫 번째 이유는 School API에서 학교 이름과 교육청 이름으로 검색을 하기 때문에 기본 제공 메서드 이외에 contains(내부 LIKE 쿼리) 같은 **추가 Query 메서드**가 필요했습니다.  
두 번째는 **페이지 처리**를 해야 하기 때문입니다. JpaRepository는 PagingAndSortingRepository를 상속하고 있지만 CrudRepository는 PagingAndSortingRepository의 상위 객체이기 때문에 JpaRepository로 변경하였습니다.

`findBySchoolFullNameContainsAndSchoolNameContains 메서드 추가`
region과 name을 파라미터로 받아 SchoolFullName에서 교육청, SchoolName에서 학교이름을 내부적으로 **LIKE**를 이용하여 검색하는 메소드를 추가했습니다. 페이징 처리를 위해 **Page** 객체를 반환합니다.
## 영향을 미치는 부분
school module : schoolSerach API 구현
