### PR TITLE
change gradle settings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ subprojects {
         annotationProcessor 'org.projectlombok:lombok'
         implementation 'org.springframework.boot:spring-boot-starter-actuator'
         implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+        testImplementation 'com.h2database:h2'
     }
 
     task initSourceFolders {

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,6 @@ subprojects {
         annotationProcessor 'org.projectlombok:lombok'
         implementation 'org.springframework.boot:spring-boot-starter-actuator'
         implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-        implementation 'org.springframework.boot:spring-boot-starter-security'
     }
 
     task initSourceFolders {
@@ -69,7 +68,6 @@ subprojects {
 
 project(':core') {
     dependencies {
-        implementation 'org.springframework.boot:spring-boot-starter-security'
         runtimeOnly 'mysql:mysql-connector-java'
     }
 
@@ -89,12 +87,12 @@ project(':auth') {
 
         implementation 'org.springframework.boot:spring-boot-starter-data-redis'
         implementation 'org.springframework.boot:spring-boot-starter-web'
+        implementation 'org.springframework.boot:spring-boot-starter-security'
         implementation 'io.jsonwebtoken:jjwt:0.9.1'
         testImplementation('org.springframework.boot:spring-boot-starter-test') {
             exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
         }
         testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
-        testImplementation 'org.springframework.security:spring-security-test'
     }
     jar {
         enabled = false
@@ -110,7 +108,6 @@ project(':info') {
             exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
         }
         testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
-        testImplementation 'org.springframework.security:spring-security-test'
     }
     jar {
         enabled = false
@@ -126,7 +123,6 @@ project(':grade') {
             exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
         }
         testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
-        testImplementation 'org.springframework.security:spring-security-test'
     }
     jar {
         enabled = false
@@ -142,7 +138,6 @@ project(':school') {
             exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
         }
         testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
-        testImplementation 'org.springframework.security:spring-security-test'
     }
     jar {
         enabled = false
@@ -158,6 +153,7 @@ project(':husky') {
         compile project(':core')
 
         implementation 'org.springframework.boot:spring-boot-starter-web'
+        implementation 'org.springframework.boot:spring-boot-starter-security'
         testImplementation('org.springframework.boot:spring-boot-starter-test') {
             exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
         }


### PR DESCRIPTION
# change gradle settings
## 목적
### 요약
* 모듈 별 security dependency 포함 여부 수정 
* h2 dependency 추가
### 상세
`모듈 별 security dependency 포함 여부 수정 `
auth, husky 모듈 이외에 다른 API 테스트에서는 Spring Security를 적용하지 않고 테스트를 진행해야 하는데 SpringSecurity 의존성이 전역 dependency에 정의되어 있어 Application의 **exclude = {SecurityAutoConfiguration.class}** 옵션으로 Spring Security 사용 해제를 할 수 없었습니다. 따라서 전역 dependency에서는 Spring Security를 제외하고 인증 관련 모듈인 auth와 통합 Application인 Huksy에서만 Spring Security 의존성을 사용하도록 변경했습니다.


`h2 dependency 추가`
아직 DB 인프라 연동이 되지 않았고 테스트 용으로는 실제 프로덕션 DB보다 테스트용 인메모리 DB가 더 적합하다고 생각되어 h2 dependency를 추가하였습니다. 실제 DB 데이터 수정 걱정 없이 Mock 테스트가 가능합니다.
## 영향을 미치는 부분
school, info, grade, auth, core, husky : 모든 Unit Test Code
