### PR TITLE
School search API 구현

### DIFF
--- a/school/src/main/java/kr/hs/entrydsm/husky/SchoolApplication.java
+++ b/school/src/main/java/kr/hs/entrydsm/husky/SchoolApplication.java
@@ -9,4 +9,5 @@ public class SchoolApplication {
     public static void main(String[] args) {
         SpringApplication.run(SchoolApplication.class, args);
     }
+
 }

--- a/school/src/main/java/kr/hs/entrydsm/husky/domain/search/controller/SchoolController.java
+++ b/school/src/main/java/kr/hs/entrydsm/husky/domain/search/controller/SchoolController.java
@@ -1,13 +1,14 @@
 package kr.hs.entrydsm.husky.domain.search.controller;
 
+import kr.hs.entrydsm.husky.domain.search.exception.AppError;
 import kr.hs.entrydsm.husky.domain.search.service.SchoolService;
 import kr.hs.entrydsm.husky.entities.schools.School;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.constraints.NotBlank;
 
@@ -21,5 +22,12 @@ public class SchoolController {
                                @RequestParam @NotBlank String name,
                                Pageable pageable) {
         return schoolService.search(eduOffice, name, pageable);
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public @ResponseBody
+    AppError vaildRequestError(MissingServletRequestParameterException e) {
+        AppError appError = new AppError(HttpStatus.BAD_REQUEST, "invalid parameter");
+        return appError;
     }
 }

--- a/school/src/main/java/kr/hs/entrydsm/husky/domain/search/controller/SchoolController.java
+++ b/school/src/main/java/kr/hs/entrydsm/husky/domain/search/controller/SchoolController.java
@@ -15,6 +15,7 @@ import javax.validation.constraints.NotBlank;
 @RequiredArgsConstructor
 @RestController
 public class SchoolController {
+
     private final SchoolService schoolService;
 
     @GetMapping("/schools")
@@ -31,4 +32,5 @@ public class SchoolController {
         AppError appError = new AppError(HttpStatus.BAD_REQUEST, "invalid parameter");
         return appError;
     }
+
 }

--- a/school/src/main/java/kr/hs/entrydsm/husky/domain/search/controller/SchoolController.java
+++ b/school/src/main/java/kr/hs/entrydsm/husky/domain/search/controller/SchoolController.java
@@ -1,0 +1,25 @@
+package kr.hs.entrydsm.husky.domain.search.controller;
+
+import kr.hs.entrydsm.husky.domain.search.service.SchoolService;
+import kr.hs.entrydsm.husky.entities.schools.School;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.constraints.NotBlank;
+
+@RequiredArgsConstructor
+@RestController
+public class SchoolController {
+    private final SchoolService schoolService;
+
+    @GetMapping("/schools")
+    public Page<School> search(@RequestParam @NotBlank String eduOffice,
+                               @RequestParam @NotBlank String name,
+                               Pageable pageable) {
+        return schoolService.search(eduOffice, name, pageable);
+    }
+}

--- a/school/src/main/java/kr/hs/entrydsm/husky/domain/search/controller/SchoolController.java
+++ b/school/src/main/java/kr/hs/entrydsm/husky/domain/search/controller/SchoolController.java
@@ -26,7 +26,7 @@ public class SchoolController {
 
     @ExceptionHandler(MissingServletRequestParameterException.class)
     public @ResponseBody
-    AppError vaildRequestError(MissingServletRequestParameterException e) {
+    AppError RequestInvalidError(MissingServletRequestParameterException e) {
         AppError appError = new AppError(HttpStatus.BAD_REQUEST, "invalid parameter");
         return appError;
     }

--- a/school/src/main/java/kr/hs/entrydsm/husky/domain/search/controller/SchoolController.java
+++ b/school/src/main/java/kr/hs/entrydsm/husky/domain/search/controller/SchoolController.java
@@ -25,6 +25,7 @@ public class SchoolController {
     }
 
     @ExceptionHandler(MissingServletRequestParameterException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
     public @ResponseBody
     AppError RequestInvalidError(MissingServletRequestParameterException e) {
         AppError appError = new AppError(HttpStatus.BAD_REQUEST, "invalid parameter");

--- a/school/src/main/java/kr/hs/entrydsm/husky/domain/search/exception/AppError.java
+++ b/school/src/main/java/kr/hs/entrydsm/husky/domain/search/exception/AppError.java
@@ -1,0 +1,12 @@
+package kr.hs.entrydsm.husky.domain.search.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public class AppError {
+    HttpStatus status;
+    String message;
+}

--- a/school/src/main/java/kr/hs/entrydsm/husky/domain/search/exception/AppError.java
+++ b/school/src/main/java/kr/hs/entrydsm/husky/domain/search/exception/AppError.java
@@ -7,6 +7,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 @Getter
 public class AppError {
+
     HttpStatus status;
     String message;
+
 }

--- a/school/src/main/java/kr/hs/entrydsm/husky/domain/search/service/SchoolService.java
+++ b/school/src/main/java/kr/hs/entrydsm/husky/domain/search/service/SchoolService.java
@@ -1,0 +1,18 @@
+package kr.hs.entrydsm.husky.domain.search.service;
+
+import kr.hs.entrydsm.husky.entities.schools.School;
+import kr.hs.entrydsm.husky.entities.schools.repositories.SchoolRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class SchoolService {
+    private final SchoolRepository schoolRepository;
+
+    public Page<School> search(String eduOffice, String name, Pageable pageable) {
+        return schoolRepository.findBySchoolFullNameContainsAndSchoolNameContains(eduOffice, name, pageable);
+    }
+}

--- a/school/src/main/java/kr/hs/entrydsm/husky/domain/search/service/SchoolService.java
+++ b/school/src/main/java/kr/hs/entrydsm/husky/domain/search/service/SchoolService.java
@@ -10,9 +10,11 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 @Service
 public class SchoolService {
+
     private final SchoolRepository schoolRepository;
 
     public Page<School> search(String eduOffice, String name, Pageable pageable) {
         return schoolRepository.findBySchoolFullNameContainsAndSchoolNameContains(eduOffice, name, pageable);
     }
+
 }

--- a/school/src/test/java/kr/hs/entrydsm/husky/domian/search/SchoolApiTest.java
+++ b/school/src/test/java/kr/hs/entrydsm/husky/domian/search/SchoolApiTest.java
@@ -1,0 +1,60 @@
+package kr.hs.entrydsm.husky.domian.search;
+
+import kr.hs.entrydsm.husky.SchoolApplication;
+import kr.hs.entrydsm.husky.entities.schools.School;
+import kr.hs.entrydsm.husky.entities.schools.repositories.SchoolRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ContextConfiguration(classes = {SchoolApplication.class})
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class SchoolApiTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private WebApplicationContext context;
+
+    private MockMvc mvc;
+
+    @BeforeEach
+    public void setup() {
+        mvc = MockMvcBuilders
+                .webAppContextSetup(context)
+                .build();
+    }
+
+    @Autowired
+    private SchoolRepository schoolRepository;
+
+    @Test
+    public void return_schools_page() throws Exception {
+        schoolRepository.save(new School("1234",
+                "대마고",
+                "대전교육청 대마고",
+                "유성구"));
+
+        String url = "http://localhost:" + port;
+
+        mvc.perform(get(url + "/schools")
+                .param("eduOffice", "대")
+                .param("name", "대")
+                .param("page", "0")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("content[0].schoolCode").value("1234"));
+    }
+}

--- a/school/src/test/java/kr/hs/entrydsm/husky/domian/search/SchoolApiTest.java
+++ b/school/src/test/java/kr/hs/entrydsm/husky/domian/search/SchoolApiTest.java
@@ -35,6 +35,7 @@ class SchoolApiTest {
 
     @BeforeEach
     public void setup() {
+
         mvc = MockMvcBuilders
                 .webAppContextSetup(context)
                 .build();
@@ -60,7 +61,8 @@ class SchoolApiTest {
     }
 
     @Test
-    public void invalid_parameter() throws Exception{
+    public void invalid_parameter_error() throws Exception{
+
         String url = "http://localhost:" + port;
 
         mvc.perform(get(url + "/schools")
@@ -70,4 +72,5 @@ class SchoolApiTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("message").value("invalid parameter"));
     }
+
 }

--- a/school/src/test/java/kr/hs/entrydsm/husky/domian/search/SchoolApiTest.java
+++ b/school/src/test/java/kr/hs/entrydsm/husky/domian/search/SchoolApiTest.java
@@ -30,22 +30,23 @@ class SchoolApiTest {
 
     private MockMvc mvc;
 
+    @Autowired
+    private SchoolRepository schoolRepository;
+
     @BeforeEach
     public void setup() {
         mvc = MockMvcBuilders
                 .webAppContextSetup(context)
                 .build();
-    }
 
-    @Autowired
-    private SchoolRepository schoolRepository;
-
-    @Test
-    public void return_schools_page() throws Exception {
         schoolRepository.save(new School("1234",
                 "대마고",
                 "대전교육청 대마고",
                 "유성구"));
+    }
+
+    @Test
+    public void return_schools_page() throws Exception {
 
         String url = "http://localhost:" + port;
 
@@ -56,5 +57,17 @@ class SchoolApiTest {
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("content[0].schoolCode").value("1234"));
+    }
+
+    @Test
+    public void invalid_parameter() throws Exception{
+        String url = "http://localhost:" + port;
+
+        mvc.perform(get(url + "/schools")
+                .param("eduOffice", "대")
+                .param("page", "0")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("message").value("invalid parameter"));
     }
 }

--- a/school/src/test/java/kr/hs/entrydsm/husky/domian/search/SchoolApiTest.java
+++ b/school/src/test/java/kr/hs/entrydsm/husky/domian/search/SchoolApiTest.java
@@ -44,6 +44,7 @@ class SchoolApiTest {
                 "대마고",
                 "대전교육청 대마고",
                 "유성구"));
+
     }
 
     @Test
@@ -58,6 +59,7 @@ class SchoolApiTest {
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("content[0].schoolCode").value("1234"));
+
     }
 
     @Test
@@ -71,6 +73,7 @@ class SchoolApiTest {
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("message").value("invalid parameter"));
+        
     }
 
 }


### PR DESCRIPTION
# School search API 구현
## 목적
### 요약
* School search API 구현
* SchoolSearch API Test Case 작성 및 Pass
### 상세
`School search API 구현`
전국 학교를 교육청(대전,부산,서울 등)과 학교명('대','대마')로 검색하는 School Search API를 구현했습니다. `@Valid`에서 throw되는 Exception이외에 다른 Exception은 없기 때문에 컨트롤러 내부에서 Exception Handler를 정의하여 처리했습니다. Page 객체를 반환하므로 API 파라미터에 page와 size를 이용해 페이지 번호와 한 번에 가져오는 개수를 지정할 수 있습니다. (페이지 번호는 0번부터 시작)
`SchoolSearch API Test Case 작성 및 Pass`
Test를 실행하기 위해 인메모리 DB인 h2를 도입하는 과정을 [PR#8](https://github.com/EntryDSM/Husky/pull/8)에서 거쳤습니다. SpringbootTest와 MockMvc를 이용하여 테스트를 구성했습니다. 테스트 케이스는 다음과 같습니다.
* School Search Test : 파라미터를 이용하여 학교 검색이 되는 지 검증 Test
* Invalid Parameter Test : 필수 파라미터를 전달하지 않았을 때 400 Reponse를 받는 지 검증 Test
## 영향을 미치는 부분
School Module