### PR TITLE
INFO - Users/status/me API&Test

### DIFF
--- a/core/src/main/java/kr/hs/entrydsm/husky/entities/users/Status.java
+++ b/core/src/main/java/kr/hs/entrydsm/husky/entities/users/Status.java
@@ -40,4 +40,8 @@ public class Status {
     @OneToOne(cascade = CascadeType.ALL)
     private User user;
 
+    public void finalSubmit() {
+        this.isFinalSubmit = true;
+    }
+
 }

--- a/core/src/main/java/kr/hs/entrydsm/husky/entities/users/repositories/StatusRepository.java
+++ b/core/src/main/java/kr/hs/entrydsm/husky/entities/users/repositories/StatusRepository.java
@@ -1,0 +1,13 @@
+package kr.hs.entrydsm.husky.entities.users.repositories;
+
+import kr.hs.entrydsm.husky.entities.users.Status;
+import kr.hs.entrydsm.husky.entities.users.User;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface StatusRepository extends CrudRepository<Status, String> {
+    Optional<Status> findByEmail(String email);
+}

--- a/info/src/main/java/kr/hs/entrydsm/husky/domain/user/controller/UserController.java
+++ b/info/src/main/java/kr/hs/entrydsm/husky/domain/user/controller/UserController.java
@@ -1,10 +1,8 @@
 package kr.hs.entrydsm.husky.domain.user.controller;
 
-import kr.hs.entrydsm.husky.domain.user.dto.SelectTypeRequest;
-import kr.hs.entrydsm.husky.domain.user.dto.SetUserInfoRequest;
-import kr.hs.entrydsm.husky.domain.user.dto.UserInfoResponse;
-import kr.hs.entrydsm.husky.domain.user.dto.UserTypeResponse;
+import kr.hs.entrydsm.husky.domain.user.dto.*;
 import kr.hs.entrydsm.husky.domain.user.service.UserInfoService;
+import kr.hs.entrydsm.husky.domain.user.service.UserStatusService;
 import kr.hs.entrydsm.husky.domain.user.service.UserTypeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -20,6 +18,7 @@ public class UserController {
 
     private final UserTypeService userTypeService;
     private final UserInfoService userInfoService;
+    private final UserStatusService userStatusService;
 
     @PatchMapping("/type")
     @ResponseStatus(value = HttpStatus.NO_CONTENT)
@@ -48,4 +47,7 @@ public class UserController {
     public UserInfoResponse getUserInfo() {
         return userInfoService.getUserInfo();
     }
+
+    @GetMapping("/status")
+    public UserStatusResponse getUserStatus() { return userStatusService.getStatus(); }
 }

--- a/info/src/main/java/kr/hs/entrydsm/husky/domain/user/controller/UserController.java
+++ b/info/src/main/java/kr/hs/entrydsm/husky/domain/user/controller/UserController.java
@@ -50,4 +50,9 @@ public class UserController {
 
     @GetMapping("/status")
     public UserStatusResponse getUserStatus() { return userStatusService.getStatus(); }
+
+    @PatchMapping("/status")
+    public UserStatusResponse finalSubmit() {
+        return userStatusService.finalSubmit();
+    }
 }

--- a/info/src/main/java/kr/hs/entrydsm/husky/domain/user/dto/UserStatusResponse.java
+++ b/info/src/main/java/kr/hs/entrydsm/husky/domain/user/dto/UserStatusResponse.java
@@ -1,0 +1,37 @@
+package kr.hs.entrydsm.husky.domain.user.dto;
+
+import kr.hs.entrydsm.husky.entities.users.Status;
+import kr.hs.entrydsm.husky.entities.users.User;
+import kr.hs.entrydsm.husky.entities.users.enums.Sex;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserStatusResponse {
+
+    private String name;
+    private Sex sex;
+    private boolean isFinalSubmit;
+    private boolean isPaid;
+    private boolean isPrintedApplicationArrived;
+    private boolean isPassedFirstApply;
+    private boolean isPassedInterview;
+
+    public static UserStatusResponse response(User user, Status status) {
+        return UserStatusResponse.builder()
+                .name(user.getName())
+                .sex(user.getSex())
+                .isFinalSubmit(status.isFinalSubmit())
+                .isPaid(status.isPaid())
+                .isPrintedApplicationArrived(status.isPrintedApplicationArrived())
+                .isPassedFirstApply(status.isPassedFirstApply())
+                .isPassedInterview(status.isPassedInterview())
+                .build();
+    }
+
+}

--- a/info/src/main/java/kr/hs/entrydsm/husky/domain/user/service/UserStatusService.java
+++ b/info/src/main/java/kr/hs/entrydsm/husky/domain/user/service/UserStatusService.java
@@ -27,6 +27,19 @@ public class UserStatusService {
         return UserStatusResponse.response(user, status);
     }
 
+    public UserStatusResponse finalSubmit() {
+        String email = SecurityContextHolder.getContext().getAuthentication().getName();
+        User user = userRepository.findByEmail(email).orElseThrow(UserNotFoundException::new);
+
+        Status status = user.getStatus();
+        if(status == null) status = createStatus(user);
+
+        status.finalSubmit();
+        statusRepository.save(status);
+
+        return UserStatusResponse.response(user, status);
+    }
+
     private Status createStatus(User user) {
         Status status = Status.builder()
                 .email(user.getEmail())

--- a/info/src/main/java/kr/hs/entrydsm/husky/domain/user/service/UserStatusService.java
+++ b/info/src/main/java/kr/hs/entrydsm/husky/domain/user/service/UserStatusService.java
@@ -1,0 +1,44 @@
+package kr.hs.entrydsm.husky.domain.user.service;
+
+import kr.hs.entrydsm.husky.domain.user.dto.UserStatusResponse;
+import kr.hs.entrydsm.husky.domain.user.exception.UserNotFoundException;
+import kr.hs.entrydsm.husky.entities.users.Status;
+import kr.hs.entrydsm.husky.entities.users.User;
+import kr.hs.entrydsm.husky.entities.users.repositories.StatusRepository;
+import kr.hs.entrydsm.husky.entities.users.repositories.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class UserStatusService {
+
+    private final UserRepository userRepository;
+    private final StatusRepository statusRepository;
+
+    public UserStatusResponse getStatus() {
+        String email = SecurityContextHolder.getContext().getAuthentication().getName();
+        User user = userRepository.findByEmail(email).orElseThrow(UserNotFoundException::new);
+
+        Status status = user.getStatus();
+        if(status == null) status = createStatus(user);
+
+        return UserStatusResponse.response(user, status);
+    }
+
+    private Status createStatus(User user) {
+        Status status = Status.builder()
+                .email(user.getEmail())
+                .user(user)
+                .isFinalSubmit(false)
+                .isPaid(false)
+                .isPrintedApplicationArrived(false)
+                .isPassedFirstApply(false)
+                .isPassedInterview(false)
+                .build();
+
+        return statusRepository.save(status);
+    }
+
+}

--- a/info/src/main/java/kr/hs/entrydsm/husky/domain/user/service/UserStatusService.java
+++ b/info/src/main/java/kr/hs/entrydsm/husky/domain/user/service/UserStatusService.java
@@ -19,20 +19,22 @@ public class UserStatusService {
 
     public UserStatusResponse getStatus() {
         String email = SecurityContextHolder.getContext().getAuthentication().getName();
-        User user = userRepository.findByEmail(email).orElseThrow(UserNotFoundException::new);
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(UserNotFoundException::new);
 
         Status status = user.getStatus();
-        if(status == null) status = createStatus(user);
+        if (status == null) status = createStatus(user);
 
         return UserStatusResponse.response(user, status);
     }
 
     public UserStatusResponse finalSubmit() {
         String email = SecurityContextHolder.getContext().getAuthentication().getName();
-        User user = userRepository.findByEmail(email).orElseThrow(UserNotFoundException::new);
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(UserNotFoundException::new);
 
         Status status = user.getStatus();
-        if(status == null) status = createStatus(user);
+        if (status == null) status = createStatus(user);
 
         status.finalSubmit();
         statusRepository.save(status);

--- a/info/src/test/java/kr/hs/entrydsm/husky/ScheduleRepositoryTest.java
+++ b/info/src/test/java/kr/hs/entrydsm/husky/ScheduleRepositoryTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.time.LocalDate;
@@ -16,6 +17,7 @@ import static org.assertj.core.api.Assertions.*;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = InfoApplication.class)
+@ActiveProfiles("test")
 public class ScheduleRepositoryTest {
 
     @Autowired

--- a/info/src/test/java/kr/hs/entrydsm/husky/UserStatusApiTest.java
+++ b/info/src/test/java/kr/hs/entrydsm/husky/UserStatusApiTest.java
@@ -74,6 +74,10 @@ class UserStatusApiTest {
                 .andDo(print())
                 .andExpect(status().isOk());
 
+        mvc.perform(patch(url + "/users/me/status"))
+                .andDo(print())
+                .andExpect(status().isOk());
+
         //then
         User user = userRepository.findByEmail("test5").orElseThrow(UserNotFoundException::new);
         System.out.println(user.getStatus().getUser().getName() + " final submitted : " +

--- a/info/src/test/java/kr/hs/entrydsm/husky/UserStatusApiTest.java
+++ b/info/src/test/java/kr/hs/entrydsm/husky/UserStatusApiTest.java
@@ -79,7 +79,8 @@ class UserStatusApiTest {
                 .andExpect(status().isOk());
 
         //then
-        User user = userRepository.findByEmail("test5").orElseThrow(UserNotFoundException::new);
+        User user = userRepository.findByEmail("test5")
+                .orElseThrow(UserNotFoundException::new);
         System.out.println(user.getStatus().getUser().getName() + " final submitted : " +
                 user.getStatus().isFinalSubmit());
     }

--- a/info/src/test/java/kr/hs/entrydsm/husky/UserStatusApiTest.java
+++ b/info/src/test/java/kr/hs/entrydsm/husky/UserStatusApiTest.java
@@ -1,0 +1,82 @@
+package kr.hs.entrydsm.husky;
+
+import kr.hs.entrydsm.husky.domain.user.exception.UserNotFoundException;
+import kr.hs.entrydsm.husky.entities.users.User;
+import kr.hs.entrydsm.husky.entities.users.enums.Sex;
+import kr.hs.entrydsm.husky.entities.users.repositories.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.time.LocalDateTime;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = InfoApplication.class,
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class UserStatusApiTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private WebApplicationContext context;
+
+    private MockMvc mvc;
+
+    @BeforeEach
+    private void setup() {
+        mvc = MockMvcBuilders
+                .webAppContextSetup(context)
+                .build();
+
+        userRepository.save(User.builder()
+                .receiptCode(5)
+                .name("huewilliams")
+                .sex(Sex.MALE)
+                .email("test5")
+                .createdAt(LocalDateTime.now())
+                .password("1234")
+                .build());
+
+    }
+
+    @AfterEach
+    public void cleanup() {
+        userRepository.deleteAll();
+    }
+
+    @Test
+    @WithMockUser(username = "test5", password = "1234")
+    public void getUserStatus() throws Exception {
+        //given
+        String url = "http://localhost:" + port;
+
+        //when
+        mvc.perform(get(url + "/users/me/status"))
+                .andDo(print())
+                .andExpect(status().isOk());
+
+        //then
+        User user = userRepository.findByEmail("test5").orElseThrow(UserNotFoundException::new);
+        System.out.println(user.getStatus().getUser().getName() + " final submitted : " +
+                user.getStatus().isFinalSubmit());
+    }
+}


### PR DESCRIPTION
# Users/status/me API 구현 및 테스트
## 목적
### 요약
* users/me/status API 구현
* status API Test
### 상세
`users/me/status API 구현`
지원자의 상태를 조회하고 지원자의 최종 제출 여부를 제출로 변경하는 기능입니다. auth에서 signUp 할 때 User를 생성하는데, 이때 Status는 생성되지 않으므로 상태 조회/갱신 요청 시 회원 상태가 생성되어 있지 않을 경우 Stutus를 생성하여 초기화하는 로직을 구현했습니다.
* GET/users/me/status : 지원자의 상태를 조회하는 API
* PATCH/users/me/status : 지원자의 최종 제출 여부를 제출함으로 변경하는 API

`status API Test`
상태 조회 및 Status 초기화, 최종 제출 여부가 변경되는 지 등을 확인하였습니다.
