### PR TITLE
Config: 배포를 위한 설정 파일 추가

### DIFF
--- a/auth/src/main/java/kr/hs/entrydsm/husky/controllers/UserAuthController.java
+++ b/auth/src/main/java/kr/hs/entrydsm/husky/controllers/UserAuthController.java
@@ -13,7 +13,7 @@ import javax.validation.constraints.Email;
 @RestController
 @RequestMapping("/user")
 @RequiredArgsConstructor
-public class UserController {
+public class UserAuthController {
 
     private final UserServiceImpl userService;
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,6 @@
-#Mon Jul 13 08:46:50 KST 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
+#Sun Aug 09 19:54:39 KST 2020
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/husky/src/main/resources/application.yml
+++ b/husky/src/main/resources/application.yml
@@ -1,0 +1,24 @@
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${MYSQL_URL}
+  redis:
+    host: ${REDIS_HOST}
+    password: ${REDIS_PASSWORD}
+
+aws:
+  credential:
+    access_key_id: ${AWS_ACCESS_KEY}
+    secret_key: ${AWS_SECRET_KEY}
+    region: ${AWS_REGION}
+
+auth:
+  jwt:
+    secret: ${JWT_SECRET_KEY}
+    exp:
+      access: ${JWT_ACCESS_EXP}
+      refresh: ${JWT_REFRESH_EXP}
+    header: ${JWT_HEADER}
+    prefix: ${JWT_PREFIX}
+  maintenance:
+    key: ${MAINTENANCE_KEY}

--- a/husky/src/test/resources/application-test.yml
+++ b/husky/src/test/resources/application-test.yml
@@ -1,3 +1,0 @@
-auth:
-  maintenance:
-    key: adminmaintenancekey

--- a/husky/src/test/resources/application-test.yml
+++ b/husky/src/test/resources/application-test.yml
@@ -1,0 +1,3 @@
+auth:
+  maintenance:
+    key: adminmaintenancekey

--- a/info/src/main/java/kr/hs/entrydsm/husky/domain/schedule/service/ScheduleService.java
+++ b/info/src/main/java/kr/hs/entrydsm/husky/domain/schedule/service/ScheduleService.java
@@ -16,15 +16,15 @@ public class ScheduleService {
 
     private final ScheduleRepository scheduleRepository;
 
-    @Value("${admin.secret.key}")
-    private String adminSecretKey;
+    @Value("${auth.maintenance.key}")
+    private String maintenanceKey;
 
     public String createSchedule(CreateScheduleRequest request, String secret) {
         byte[] targetBytes = secret.getBytes();
         Base64.Encoder encoder = Base64.getEncoder();
         byte[] encodeBytes = encoder.encode(targetBytes);
 
-        if(!adminSecretKey.equals(new String(encodeBytes))) {
+        if (!maintenanceKey.equals(new String(encodeBytes))) {
             throw new NotAdminException();
         }
 

--- a/info/src/main/java/kr/hs/entrydsm/husky/domain/user/controller/UserInfoController.java
+++ b/info/src/main/java/kr/hs/entrydsm/husky/domain/user/controller/UserInfoController.java
@@ -8,13 +8,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
-import javax.transaction.Transactional;
 import javax.validation.Valid;
 
 @RequiredArgsConstructor
 @RequestMapping("/users/me")
 @RestController
-public class UserController {
+public class UserInfoController {
 
     private final UserTypeService userTypeService;
     private final UserInfoService userInfoService;

--- a/info/src/test/resources/application-test.properties
+++ b/info/src/test/resources/application-test.properties
@@ -1,2 +1,0 @@
-admin.secret.key=dGVzdA==
-spring.jackson.property-naming-strategy=SNAKE_CASE

--- a/info/src/test/resources/application-test.yml
+++ b/info/src/test/resources/application-test.yml
@@ -1,0 +1,7 @@
+spring:
+  jackson:
+    property-naming-strategy: SNAKE_CASE
+
+auth:
+  maintenance:
+    key: dGVzdA==


### PR DESCRIPTION
# 배포를 위한 설정 파일 추가
## 목적
### 요약
중구난방이던 config property를 획일화하여 유지보수성을 개선하고 이름이 충돌하는 빈(`UserController`)을 `UserAuthController`, `UserInfoController`로 각각 이름을 변경했다.
### 상세
팀원 모두 각자 다른 환경에서 개발하다보니 application.yml을 제외하고 원격 저장소에 코드를 커밋하여 CD가 정상적으로 작동하지 않는 문제가 발생했다. 이에 메인 모듈 `husky`에 application.yml을 추가하여 배포를 막고 있던 걸림돌을 제거해 빠른 시일 내로 CD를 정상화할 수 있을 것으로 기대된다. 또한 auth 모듈의 `UserController`와 info 모듈의 `UserController`의 이름이 중복되어 웹 애플리케이션 최초 실행 당시에 런타임 에러가 발생한다는 문제점이 있어 각각 `UserAuthController`, `UserInfoController`로 클래스 이름을 변경하여 이를 해결했다.
## 영향을 미치는 부분
- 클래스 이름
- application.yml 추가
- Deploy