### PR TITLE
[FIX] 지원자 사진을 null로 설정할 수 있게끔 변경

### DIFF
--- a/src/main/java/kr/hs/entrydsm/husky/domain/user/domain/User.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/user/domain/User.java
@@ -130,7 +130,7 @@ public class User extends BaseTimeEntity {
         setIfNotNull(this::setAddress, dto.getAddress());
         setIfNotNull(this::setDetailAddress, dto.getDetailAddress());
         setIfNotNull(this::setPostCode, dto.getPostCode());
-        setIfNotNull(this::setUserPhoto, dto.getPhoto());
+        this.userPhoto = dto.getPhoto();
     }
 
     private <T> void setIfNotNull(final Consumer<T> setter, final T value) {


### PR DESCRIPTION
# 지원자 사진을 null로 설정할 수 있게끔 변경
## 목적
### 요약
프론트측 요청에 따라 지원자의 사진을 null로 설정할 수 있게끔 Entity 내 DTO 수용 메서드를 수정했습니다.
### 상세
현재 Husky 프로젝트의 지원자 정보 업데이트 방식은 모두 null이 아닌 값만 적용하는 식으로 구현되어 있습니다. 입학원서 특성상 최종 제출을 위해서는 모든 칸의 정보를 기입해야 하기 때문입니다. 하지만 지원자 사진의 경우 예외로 두고 null로 수정할 수 있게 변경해달라는 프론트측의 요청에 따라 이를 수정하게 되었습니다.
## 영향을 미치는 부분
- User::update(SetUserInfoRequest dto)
