### PR TITLE
GET info API 수정 

### DIFF
--- a/src/main/java/kr/hs/entrydsm/husky/domain/application/domain/GeneralApplication.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/application/domain/GeneralApplication.java
@@ -11,6 +11,7 @@ import javax.persistence.Column;
 import javax.persistence.JoinColumn;
 import javax.persistence.MappedSuperclass;
 import javax.persistence.OneToOne;
+import java.time.LocalDate;
 import java.util.function.Consumer;
 
 @Getter
@@ -27,6 +28,9 @@ public abstract class GeneralApplication extends BaseTimeEntity {
 
     @Column(length = 20)
     private String schoolTel;
+
+    @Column
+    private LocalDate graduatedDate;
 
     @Column
     private Integer volunteerTime;
@@ -71,6 +75,10 @@ public abstract class GeneralApplication extends BaseTimeEntity {
 
     public void update(School school) {
         setIfNotNull(this::setSchool, school);
+    }
+
+    protected void updateGraduatedDate(LocalDate graduatedDate) {
+        this.graduatedDate = graduatedDate;
     }
 
     protected void updateVolunteerAndAttendance(SetScoreRequest dto) {
@@ -124,13 +132,14 @@ public abstract class GeneralApplication extends BaseTimeEntity {
 
     protected GeneralApplication() {}
 
-    public GeneralApplication(String studentNumber, School school, String schoolTel, Integer volunteerTime,
-                              Integer fullCutCount, Integer periodCutCount, Integer lateCount, Integer earlyLeaveCount,
-                              String korean, String social, String history, String math, String science,
-                              String techAndHome, String english) {
+    public GeneralApplication(String studentNumber, School school, String schoolTel, LocalDate graduatedDate,
+                              Integer volunteerTime, Integer fullCutCount, Integer periodCutCount,
+                              Integer lateCount, Integer earlyLeaveCount, String korean, String social,
+                              String history, String math, String science, String techAndHome, String english) {
         this.studentNumber = studentNumber;
         this.school = school;
         this.schoolTel = schoolTel;
+        this.graduatedDate = graduatedDate;
         this.volunteerTime = volunteerTime;
         this.fullCutCount = fullCutCount;
         this.periodCutCount = periodCutCount;

--- a/src/main/java/kr/hs/entrydsm/husky/domain/application/domain/GraduatedApplication.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/application/domain/GraduatedApplication.java
@@ -24,12 +24,9 @@ public class GraduatedApplication extends GeneralApplication {
     @PrimaryKeyJoinColumn
     private User user;
 
-    @Column
-    private LocalDate graduatedDate;
-
     public GraduatedApplication update(SelectTypeRequest dto) {
         if (dto.getGraduatedDate() != null)
-            this.graduatedDate = dto.getGraduatedDate().atDay(1);
+            super.updateGraduatedDate(dto.getGraduatedDate().atDay(1));
         return this;
     }
 
@@ -45,9 +42,8 @@ public class GraduatedApplication extends GeneralApplication {
 
     @Builder(builderMethodName = "graduatedApplicationBuilder")
     public GraduatedApplication(Integer receiptCode, String studentNumber, School school, String schoolTel, Integer volunteerTime, Integer fullCutCount, Integer periodCutCount, Integer lateCount, Integer earlyLeaveCount, String korean, String social, String history, String math, String science, String techAndHome, String english, LocalDate graduatedDate) {
-        super(studentNumber, school, schoolTel, volunteerTime, fullCutCount, periodCutCount, lateCount, earlyLeaveCount, korean, social, history, math, science, techAndHome, english);
+        super(studentNumber, school, schoolTel, graduatedDate, volunteerTime, fullCutCount, periodCutCount, lateCount, earlyLeaveCount, korean, social, history, math, science, techAndHome, english);
         this.receiptCode = receiptCode;
-        this.graduatedDate = graduatedDate;
     }
 
 }

--- a/src/main/java/kr/hs/entrydsm/husky/domain/application/domain/UnGraduatedApplication.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/application/domain/UnGraduatedApplication.java
@@ -3,11 +3,13 @@ package kr.hs.entrydsm.husky.domain.application.domain;
 import kr.hs.entrydsm.husky.domain.application.dto.SetScoreRequest;
 import kr.hs.entrydsm.husky.domain.school.domain.School;
 import kr.hs.entrydsm.husky.domain.user.domain.User;
+import kr.hs.entrydsm.husky.domain.user.dto.SelectTypeRequest;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.time.LocalDate;
 
 @Getter
 @Entity(name = "ungraduated_application")
@@ -22,6 +24,12 @@ public class UnGraduatedApplication extends GeneralApplication {
     @PrimaryKeyJoinColumn
     private User user;
 
+    public UnGraduatedApplication update(SelectTypeRequest dto) {
+        if (dto.getGedPassDate() != null)
+            super.updateGraduatedDate(dto.getGraduatedDate().atDay(1));
+        return this;
+    }
+
     public UnGraduatedApplication update(SetScoreRequest dto) {
         updateVolunteerAndAttendance(dto);
         updateGrade(dto);
@@ -33,8 +41,8 @@ public class UnGraduatedApplication extends GeneralApplication {
     }
 
     @Builder(builderMethodName = "unGraduatedApplicationBuilder")
-    public UnGraduatedApplication(Integer receiptCode, String studentNumber, School school, String schoolTel, Integer volunteerTime, Integer fullCutCount, Integer periodCutCount, Integer lateCount, Integer earlyLeaveCount, String korean, String social, String history, String math, String science, String techAndHome, String english) {
-        super(studentNumber, school, schoolTel, volunteerTime, fullCutCount, periodCutCount, lateCount, earlyLeaveCount, korean, social, history, math, science, techAndHome, english);
+    public UnGraduatedApplication(Integer receiptCode, String studentNumber, School school, String schoolTel, LocalDate graduatedDate, Integer volunteerTime, Integer fullCutCount, Integer periodCutCount, Integer lateCount, Integer earlyLeaveCount, String korean, String social, String history, String math, String science, String techAndHome, String english) {
+        super(studentNumber, school, schoolTel, graduatedDate, volunteerTime, fullCutCount, periodCutCount, lateCount, earlyLeaveCount, korean, social, history, math, science, techAndHome, english);
         this.receiptCode = receiptCode;
     }
 

--- a/src/main/java/kr/hs/entrydsm/husky/domain/application/dto/SetDocsRequest.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/application/dto/SetDocsRequest.java
@@ -12,6 +12,6 @@ import javax.validation.constraints.Size;
 @NoArgsConstructor
 @AllArgsConstructor
 public class SetDocsRequest {
-    @NotEmpty @NotBlank @Size(max = 1600)
+    @Size(max = 1600)
     private String content;
 }

--- a/src/main/java/kr/hs/entrydsm/husky/domain/image/service/S3ImageServiceImpl.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/image/service/S3ImageServiceImpl.java
@@ -62,7 +62,7 @@ public class S3ImageServiceImpl extends AWS4Signer implements ImageService {
         String originalFilename = file.getOriginalFilename();
         String ext = originalFilename.substring( originalFilename.lastIndexOf(".") + 1);
         String randomName = UUID.randomUUID().toString();
-        String filename = randomName + "." + ext;
+        String filename = "images/" + randomName + "." + ext;
 
         s3.putObject(new PutObjectRequest(bucket, filename, file.getInputStream(), null)
                 .withCannedAcl(CannedAccessControlList.AuthenticatedRead));
@@ -72,7 +72,8 @@ public class S3ImageServiceImpl extends AWS4Signer implements ImageService {
 
     @Override
     public String generateObjectUrl(String objectName) throws MalformedURLException {
-        URL endpointUrl = new URL("https://" + baseImageUrl + ".s3." + region + ".amazonaws.com/" + objectName);
+        URL endpointUrl = new URL("https://" + baseImageUrl + ".s3." + region + ".amazonaws.com/images/"
+                + objectName);
 
         // X-Amz-Algorithm
         String x_amz_algorithm = SCHEME + "-" + ALGORITHM;

--- a/src/main/java/kr/hs/entrydsm/husky/domain/user/domain/User.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/user/domain/User.java
@@ -160,8 +160,9 @@ public class User extends BaseTimeEntity {
     }
 
     public boolean isFilledInfo() {
-        return name != null && sex != null && birthDate != null && applicantTel != null && parentTel != null &&
-                parentName != null && address != null && detailAddress != null && postCode != null && userPhoto != null;
+        return !name.isBlank() && sex != null && birthDate != null && applicantTel != null && parentTel != null &&
+                !parentName.isBlank() && !address.isBlank() && !detailAddress.isBlank() && !postCode.isBlank() &&
+                userPhoto != null;
     }
 
     public boolean isFilledType() {

--- a/src/main/java/kr/hs/entrydsm/husky/domain/user/domain/User.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/user/domain/User.java
@@ -127,7 +127,7 @@ public class User extends BaseTimeEntity {
         setIfNotNull(this::setParentName, dto.getParentName());
         setIfNotNull(this::setParentTel, dto.getParentTel());
         setIfNotNull(this::setApplicantTel, dto.getApplicantTel());
-        setIfNotNull(this::setHomeTel, dto.getHomeTel());
+        this.homeTel = dto.getHomeTel();
         setIfNotNull(this::setAddress, dto.getAddress());
         setIfNotNull(this::setDetailAddress, dto.getDetailAddress());
         setIfNotNull(this::setPostCode, dto.getPostCode());

--- a/src/main/java/kr/hs/entrydsm/husky/domain/user/domain/User.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/user/domain/User.java
@@ -7,6 +7,7 @@ import kr.hs.entrydsm.husky.domain.user.domain.enums.GradeType;
 import kr.hs.entrydsm.husky.domain.user.domain.enums.Sex;
 import kr.hs.entrydsm.husky.domain.user.dto.SelectTypeRequest;
 import kr.hs.entrydsm.husky.domain.user.dto.SetUserInfoRequest;
+import kr.hs.entrydsm.husky.global.util.Validator;
 import lombok.*;
 
 import javax.persistence.*;
@@ -16,6 +17,7 @@ import java.util.function.Consumer;
 import static kr.hs.entrydsm.husky.domain.user.domain.enums.ApplyType.COMMON;
 import static kr.hs.entrydsm.husky.domain.user.domain.enums.ApplyType.MEISTER;
 import static kr.hs.entrydsm.husky.domain.user.domain.enums.GradeType.*;
+import static kr.hs.entrydsm.husky.global.util.Validator.isBlank;
 
 @Getter
 @Setter
@@ -160,8 +162,8 @@ public class User extends BaseTimeEntity {
     }
 
     public boolean isFilledInfo() {
-        return !name.isBlank() && sex != null && birthDate != null && applicantTel != null && parentTel != null &&
-                !parentName.isBlank() && !address.isBlank() && !detailAddress.isBlank() && !postCode.isBlank() &&
+        return isBlank(name) && sex != null && birthDate != null && applicantTel != null && parentTel != null &&
+                isBlank(parentName) && isBlank(address) && isBlank(detailAddress) && isBlank(postCode) &&
                 userPhoto != null;
     }
 

--- a/src/main/java/kr/hs/entrydsm/husky/domain/user/service/UserTypeService.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/user/service/UserTypeService.java
@@ -84,7 +84,9 @@ public class UserTypeService {
 
             case GRADUATED:
             case UNGRADUATED:
-                GeneralApplication generalApplication = new GeneralApplicationAdapter(user).getGeneralApplication();
+                GeneralApplication generalApplication = user.getGeneralApplication();
+                if(generalApplication == null)
+                    return UserTypeResponse.response(user, null, null);
                 graduatedDate = generalApplication.getGraduatedDate();
                 break;
         }

--- a/src/main/java/kr/hs/entrydsm/husky/domain/user/service/UserTypeService.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/user/service/UserTypeService.java
@@ -85,7 +85,7 @@ public class UserTypeService {
             case GRADUATED:
             case UNGRADUATED:
                 GeneralApplication generalApplication = user.getGeneralApplication();
-                if(generalApplication == null)
+                if (generalApplication == null)
                     return UserTypeResponse.response(user, null, null);
                 graduatedDate = generalApplication.getGraduatedDate();
                 break;

--- a/src/main/java/kr/hs/entrydsm/husky/domain/user/service/UserTypeService.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/user/service/UserTypeService.java
@@ -1,8 +1,10 @@
 package kr.hs.entrydsm.husky.domain.user.service;
 
 import kr.hs.entrydsm.husky.domain.application.domain.GEDApplication;
+import kr.hs.entrydsm.husky.domain.application.domain.GeneralApplication;
 import kr.hs.entrydsm.husky.domain.application.domain.GraduatedApplication;
 import kr.hs.entrydsm.husky.domain.application.domain.UnGraduatedApplication;
+import kr.hs.entrydsm.husky.domain.application.domain.adapter.GeneralApplicationAdapter;
 import kr.hs.entrydsm.husky.domain.application.domain.repositories.GEDApplicationRepository;
 import kr.hs.entrydsm.husky.domain.application.domain.repositories.GraduatedApplicationRepository;
 import kr.hs.entrydsm.husky.domain.application.domain.repositories.UnGraduatedApplicationRepository;
@@ -58,6 +60,7 @@ public class UserTypeService {
         } else if (user.isUngraduated()) {
             unGraduatedRepository.findById(user.getReceiptCode())
                     .or(() -> Optional.of(new UnGraduatedApplication(user.getReceiptCode())))
+                    .map(unGraduated -> unGraduated.update(dto))
                     .ifPresent(applicationAsyncRepository::save);
         }
     }
@@ -80,9 +83,9 @@ public class UserTypeService {
                 break;
 
             case GRADUATED:
-                GraduatedApplication graduatedApplication = graduatedRepository.findById(user.getReceiptCode())
-                        .orElseThrow(ApplicationNotFoundException::new);
-                graduatedDate = graduatedApplication.getGraduatedDate();
+            case UNGRADUATED:
+                GeneralApplication generalApplication = new GeneralApplicationAdapter(user).getGeneralApplication();
+                graduatedDate = generalApplication.getGraduatedDate();
                 break;
         }
 

--- a/src/main/java/kr/hs/entrydsm/husky/global/util/Validator.java
+++ b/src/main/java/kr/hs/entrydsm/husky/global/util/Validator.java
@@ -1,0 +1,7 @@
+package kr.hs.entrydsm.husky.global.util;
+
+public class Validator {
+    public static boolean isBlank(String target) {
+        return target == null || target.isBlank();
+    }
+}


### PR DESCRIPTION
# GET info API 수정 : 비졸업자 졸업예정일 추가
## 목적
### 요약
`GET/users/me/type` , `PATCH/users/me/type` API 요청과 응답에서 비졸업자도 졸업예정일이 추가됨.
### 상세
1. 선생님과 상의 결과 비졸업자도 졸업예정일을 입력받아야 한다고 하셨고, 프론트에서 연도는 고정하고 월만 정하여 요청한다. 
`GraduatedApplication`과 `UngraduatedApplication` 모두 `graduatedDate` 가 사용되므로 상위 객체인 `GeneralApplication`에 `graduatedDate`를 추가했고 `graduateDate`를 설정하는 서비스 로직도 `GeneralApplication`을 이용하여 중복되는 처리를 없앴다.

2. homeTel에 데이터를 넣은 후 데이터를 다시 없애고 싶을 수 있다는 요구사항이 발견되었다. 이에 따라 homeTel을 null로 보낼 시 null로 설정되도록 setter를 수정하였다. 

3. 자기소개서, 학업계획서 `@NotBlanck` `@NotEmpty` validation 제거(빈 문자열 요청 허용)

4. 검증 로직 강화(빈 문자열도 검사하도록 변경)
  * isFilled 메서드 수정

5. 이미지 파일 저장 디렉토리 변경
S3 버킷 내부의 `images` 디렉토리에 저장하도록 변경
## 영향을 미치는 부분
* GeneralApplication
* API Request&Response
