### PR TITLE
HOT FIX: generate image url 변경

### DIFF
--- a/src/main/java/kr/hs/entrydsm/husky/domain/image/service/S3ImageServiceImpl.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/image/service/S3ImageServiceImpl.java
@@ -72,8 +72,7 @@ public class S3ImageServiceImpl extends AWS4Signer implements ImageService {
 
     @Override
     public String generateObjectUrl(String objectName) throws MalformedURLException {
-        URL endpointUrl = new URL("https://" + baseImageUrl + ".s3." + region + ".amazonaws.com/images/"
-                + objectName);
+        URL endpointUrl = new URL("https://" + baseImageUrl + ".s3." + region + ".amazonaws.com/" + objectName);
 
         // X-Amz-Algorithm
         String x_amz_algorithm = SCHEME + "-" + ALGORITHM;


### PR DESCRIPTION
# HOT FIX: generate image url 변경
## 목적
### 요약
이미지 처리 프로세스가 이미지 업로드 시 `images` 디렉토리에 저장됬다가 람다 함수가 리사이징을 처리한 후에는 `images` 폴더의 이미지가 삭제되고, 루트 위치에 이미지가 생성되므로 루트 주소로 이미지 url을 발급해야 한다.
