### PR TITLE
[FIX] upload return image url 변경

### DIFF
--- a/src/main/java/kr/hs/entrydsm/husky/domain/image/service/S3ImageServiceImpl.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/image/service/S3ImageServiceImpl.java
@@ -62,9 +62,9 @@ public class S3ImageServiceImpl extends AWS4Signer implements ImageService {
         String originalFilename = file.getOriginalFilename();
         String ext = originalFilename.substring( originalFilename.lastIndexOf(".") + 1);
         String randomName = UUID.randomUUID().toString();
-        String filename = "images/" + randomName + "." + ext;
+        String filename = randomName + "." + ext;
 
-        s3.putObject(new PutObjectRequest(bucket, filename, file.getInputStream(), null)
+        s3.putObject(new PutObjectRequest(bucket, "images/" + filename, file.getInputStream(), null)
                 .withCannedAcl(CannedAccessControlList.AuthenticatedRead));
 
         return filename;


### PR DESCRIPTION
# [FIX] upload return image url 변경
## 목적
### 요약
generateImageUrl 뿐만 아니라 upload 완료 후 return하는 imageUrl에도 `images/` 경로가 없어져야 한다.

 