### PR TITLE
Hotfix: 출석점수 산출 시 NPE 예외처리

### DIFF
--- a/src/main/java/kr/hs/entrydsm/husky/domain/application/domain/GraduatedApplication.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/application/domain/GraduatedApplication.java
@@ -34,6 +34,18 @@ public class GraduatedApplication extends GeneralApplication {
 
     public GraduatedApplication(Integer receiptCode) {
         this.receiptCode = receiptCode;
+        this.setVolunteerTime(0);
+        this.setEarlyLeaveCount(0);
+        this.setLateCount(0);
+        this.setFullCutCount(0);
+        this.setPeriodCutCount(0);
+        this.setKorean("XXXXXX");
+        this.setSocial("XXXXXX");
+        this.setHistory("XXXXXX");
+        this.setMath("XXXXXX");
+        this.setScience("XXXXXX");
+        this.setTechAndHome("XXXXXX");
+        this.setEnglish("XXXXXX");
     }
 
     @Builder(builderMethodName = "graduatedApplicationBuilder")

--- a/src/main/java/kr/hs/entrydsm/husky/domain/application/domain/UnGraduatedApplication.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/application/domain/UnGraduatedApplication.java
@@ -35,6 +35,18 @@ public class UnGraduatedApplication extends GeneralApplication {
 
     public UnGraduatedApplication(Integer receiptCode) {
         this.receiptCode = receiptCode;
+        this.setVolunteerTime(0);
+        this.setEarlyLeaveCount(0);
+        this.setLateCount(0);
+        this.setFullCutCount(0);
+        this.setPeriodCutCount(0);
+        this.setKorean("XXXXXX");
+        this.setSocial("XXXXXX");
+        this.setHistory("XXXXXX");
+        this.setMath("XXXXXX");
+        this.setScience("XXXXXX");
+        this.setTechAndHome("XXXXXX");
+        this.setEnglish("XXXXXX");
     }
 
     @Builder(builderMethodName = "unGraduatedApplicationBuilder")

--- a/src/main/java/kr/hs/entrydsm/husky/domain/grade/service/GradeCalcServiceImpl.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/grade/service/GradeCalcServiceImpl.java
@@ -59,13 +59,17 @@ public class GradeCalcServiceImpl implements GradeCalcService {
             return 0;
         }
 
-        int odmission = generalApplication.getLateCount()
-                + generalApplication.getEarlyLeaveCount() + generalApplication.getPeriodCutCount();
+        try {
+            int odmission = generalApplication.getLateCount()
+                    + generalApplication.getEarlyLeaveCount() + generalApplication.getPeriodCutCount();
 
-        if (odmission != 0) odmission /= 3;
-        int conversionAbsence = generalApplication.getFullCutCount() + odmission;
+            if (odmission != 0) odmission /= 3;
+            int conversionAbsence = generalApplication.getFullCutCount() + odmission;
+            return DEFAULT_ATTENDANCE_SCORE - conversionAbsence;
 
-        return DEFAULT_ATTENDANCE_SCORE - conversionAbsence;
+        } catch (NullPointerException e) {
+            return 0;
+        }
     }
 
     private BigDecimal calcVolunteerScore(User user, GeneralApplication generalApplication) {


### PR DESCRIPTION
# Hotfix: 출석점수 산출 시 NPE 예외처리
## 목적
### 요약
출석점수 산출 과정에서 NPE가 발생할 경우, 원서 출력 시 422 UNPROCESSABLE ENTITY가 발생하는 버그를 수정
### 상세
- GraduatedApplciation, UnGraduatedApplication 엔티티 생성자에 기본값 설정 추가
- 성적 점수 산출 함수(GradeCalcService::calcGradeScore)에 NullPointerException 예외처리
## 영향을 미치는 부분
- Entity 레이어, GradeCalcService
