### PR TITLE
jpa.generate-ddl 설정 비활성화

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,4 @@
 spring:
-  jpa:
-    generate-ddl: true
   datasource:
     url: ${MYSQL_URL}
 


### PR DESCRIPTION
# jpa.generate-ddl 설정 비활성화
## 목적
### 요약
개발의 편의성을 위해 분리되었던 entry 스키마와 husky 스키마를 합치는 작업을 위해 엔티티를 기반해 자동으로 DDL을 생성하는 속성인 spring.jpa.generate-ddl 설정을 비활성화 했습니다.

## 영향을 미치는 부분
- 스키마가 변경되어 누락된 부분이 있어도 더 이상 자동으로 필드를 생성하지 않음
