### PR TITLE
[Hotfix] 전형정보 업데이트 불가

### DIFF
--- a/src/main/java/kr/hs/entrydsm/husky/domain/application/domain/repositories/async/GeneralApplicationAsyncRepositoryImpl.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/application/domain/repositories/async/GeneralApplicationAsyncRepositoryImpl.java
@@ -14,11 +14,15 @@ public class GeneralApplicationAsyncRepositoryImpl implements GeneralApplication
     private final ApplicationAsyncRepository applicationAsyncRepository;
 
     @Override
-    public void save(GeneralApplicationAdapter application) {
-        if (application.getGradeType().equals(UNGRADUATED))
-            applicationAsyncRepository.save(application.getUnGraduatedApplication());
-        else if (application.getGradeType().equals(GRADUATED))
-            applicationAsyncRepository.save(application.getGraduatedApplication());
+    public void save(GeneralApplicationAdapter adapter) {
+        switch (adapter.getGradeType()) {
+            case UNGRADUATED:
+                applicationAsyncRepository.save(adapter.getUnGraduatedApplication());
+                break;
+
+            case GRADUATED:
+                applicationAsyncRepository.save(adapter.getGraduatedApplication());
+        }
     }
 
 }

--- a/src/main/java/kr/hs/entrydsm/husky/domain/application/service/ApplicationService.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/application/service/ApplicationService.java
@@ -133,12 +133,12 @@ public class ApplicationService {
         switch (gradeType) {
             case GRADUATED:
                 GraduatedApplication graduated = graduatedApplicationRepository.findById(receiptCode)
-                        .orElse(initGraduatedApplication(receiptCode));
+                        .orElseGet(() -> initGraduatedApplication(receiptCode));
                 return new GeneralApplicationAdapter(graduated);
 
             case UNGRADUATED:
-                UnGraduatedApplication unGraduated = unGraduatedApplicationRepository.findById(receiptCode)
-                        .orElse(initUnGraduatedApplication(receiptCode));
+                UnGraduatedApplication unGraduated = unGraduatedApplicationRepository.findByReceiptCode(receiptCode)
+                        .orElseGet(() -> initUnGraduatedApplication(receiptCode));
                 return new GeneralApplicationAdapter(unGraduated);
 
             default:

--- a/src/main/java/kr/hs/entrydsm/husky/domain/application/service/ApplicationService.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/application/service/ApplicationService.java
@@ -137,7 +137,7 @@ public class ApplicationService {
                 return new GeneralApplicationAdapter(graduated);
 
             case UNGRADUATED:
-                UnGraduatedApplication unGraduated = unGraduatedApplicationRepository.findByReceiptCode(receiptCode)
+                UnGraduatedApplication unGraduated = unGraduatedApplicationRepository.findById(receiptCode)
                         .orElseGet(() -> initUnGraduatedApplication(receiptCode));
                 return new GeneralApplicationAdapter(unGraduated);
 

--- a/src/main/java/kr/hs/entrydsm/husky/domain/user/dto/SetUserInfoRequest.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/user/dto/SetUserInfoRequest.java
@@ -19,7 +19,7 @@ import java.time.LocalDate;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class SetUserInfoRequest {
 
-    private static final String PHONE_REGEX = "(^\\+82[.-][1-9]\\d?[.-]|^\\(?0[1-9]\\d?\\)?[.-]?)?[1-9]\\d{2,3}[.-]\\d{4}$";
+    private static final String PHONE_REGEX = "(^\\+82[.-][1-9]\\d?[.-]|^\\(?0[0-9]\\d?\\)?[.-]?)?[0-9]\\d{2,3}[.-]\\d{4}$";
 
     @Size(max = 15)
     private String name;


### PR DESCRIPTION
# [Hotfix] 전형정보 업데이트 불가
## 목적
### 요약
- optional 객체를 다룰 때 orElse() 메서드로 값이 없을 때 기본값을 삽입하는 함수를 값이 있을 때에도 호출해 조회할 때마다 기본값으로 초기화되는 크리티컬 이슈가 발견되었습니다. 본 PR은 해당 이슈를 수정한 것입니다.

### 상세
- Optional<T>.orElse()를 Optional<T>.orElseGet()으로 변경
- 전화번호 정규식 수정(0 허용)
- 코드 가독성을 향상시키기 위해서 if 분기문을 switch-case 구문으로 변경
