### PR TITLE
[HOTFIX] 학번이 공백일 경우 예외처리

### DIFF
--- a/src/main/java/kr/hs/entrydsm/husky/domain/application/domain/GeneralApplication.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/application/domain/GeneralApplication.java
@@ -3,7 +3,6 @@ package kr.hs.entrydsm.husky.domain.application.domain;
 import kr.hs.entrydsm.husky.domain.application.dto.SetScoreRequest;
 import kr.hs.entrydsm.husky.domain.school.domain.School;
 import kr.hs.entrydsm.husky.domain.user.dto.SetUserInfoRequest;
-import kr.hs.entrydsm.husky.global.util.Validator;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
@@ -15,7 +14,7 @@ import javax.persistence.OneToOne;
 import java.time.LocalDate;
 import java.util.function.Consumer;
 
-import static kr.hs.entrydsm.husky.global.util.Validator.isExist;
+import static kr.hs.entrydsm.husky.global.util.Validator.isExists;
 
 @Getter
 @Setter(AccessLevel.PROTECTED)
@@ -130,7 +129,7 @@ public abstract class GeneralApplication extends BaseTimeEntity {
     }
 
     public String getSchoolClass() {
-        return (isExist(studentNumber)) ? studentNumber.substring(1, 3).replace("0", "") : null;
+        return (isExists(studentNumber)) ? studentNumber.substring(1, 3).replace("0", "") : null;
     }
 
     protected GeneralApplication() {}

--- a/src/main/java/kr/hs/entrydsm/husky/domain/application/domain/GeneralApplication.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/application/domain/GeneralApplication.java
@@ -3,6 +3,7 @@ package kr.hs.entrydsm.husky.domain.application.domain;
 import kr.hs.entrydsm.husky.domain.application.dto.SetScoreRequest;
 import kr.hs.entrydsm.husky.domain.school.domain.School;
 import kr.hs.entrydsm.husky.domain.user.dto.SetUserInfoRequest;
+import kr.hs.entrydsm.husky.global.util.Validator;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
@@ -13,6 +14,8 @@ import javax.persistence.MappedSuperclass;
 import javax.persistence.OneToOne;
 import java.time.LocalDate;
 import java.util.function.Consumer;
+
+import static kr.hs.entrydsm.husky.global.util.Validator.isExist;
 
 @Getter
 @Setter(AccessLevel.PROTECTED)
@@ -127,7 +130,7 @@ public abstract class GeneralApplication extends BaseTimeEntity {
     }
 
     public String getSchoolClass() {
-        return (studentNumber != null) ? studentNumber.substring(1, 3).replace("0", "") : null;
+        return (isExist(studentNumber)) ? studentNumber.substring(1, 3).replace("0", "") : null;
     }
 
     protected GeneralApplication() {}

--- a/src/main/java/kr/hs/entrydsm/husky/domain/user/domain/User.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/user/domain/User.java
@@ -16,7 +16,7 @@ import java.util.function.Consumer;
 import static kr.hs.entrydsm.husky.domain.user.domain.enums.ApplyType.COMMON;
 import static kr.hs.entrydsm.husky.domain.user.domain.enums.ApplyType.MEISTER;
 import static kr.hs.entrydsm.husky.domain.user.domain.enums.GradeType.*;
-import static kr.hs.entrydsm.husky.global.util.Validator.isExist;
+import static kr.hs.entrydsm.husky.global.util.Validator.isExists;
 
 @Getter
 @Setter
@@ -138,8 +138,8 @@ public class User extends BaseTimeEntity {
     }
 
     public boolean isFilledInfo() {
-        return isExist(name) && sex != null && birthDate != null && isExist(applicantTel) && isExist(parentTel) &&
-                isExist(parentName) && isExist(address) && isExist(detailAddress) && isExist(postCode) &&
+        return isExists(name) && sex != null && birthDate != null && isExists(applicantTel) && isExists(parentTel) &&
+                isExists(parentName) && isExists(address) && isExists(detailAddress) && isExists(postCode) &&
                 userPhoto != null;
     }
 

--- a/src/main/java/kr/hs/entrydsm/husky/global/util/Validator.java
+++ b/src/main/java/kr/hs/entrydsm/husky/global/util/Validator.java
@@ -6,8 +6,8 @@ public class Validator {
     }
 
     public static boolean isExist(String target) {
-        if(target == null) return false;
+        if (target == null) return false;
         return !target.isBlank();
     }
-    
+
 }

--- a/src/main/java/kr/hs/entrydsm/husky/global/util/Validator.java
+++ b/src/main/java/kr/hs/entrydsm/husky/global/util/Validator.java
@@ -5,7 +5,7 @@ public class Validator {
         return target == null || target.isBlank();
     }
 
-    public static boolean isExist(String target) {
+    public static boolean isExists(String target) {
         if (target == null) return false;
         return !target.isBlank();
     }


### PR DESCRIPTION
# [HOTFIX] 학번이 공백일 경우 예외처리
## 목적
### 요약
- 학번 정보를 가공해 반을 추출하는 과정에서 `StringIndexOutOfBoundsException`이 발생하는 버그 수정

### 상세
PDF 원서출력 시 '학번' 데이터에서 5자리 학번에서 인덱스를 이용해 '반' 정보를 추출하고 이를 기입합니다. 인덱스로 반 정보를 추출하는 과정에서 학번이 null인 경우 반 정보를 기재하지 않았습니다. 하지만 빈 문자열로 기재된 경우 null이 아니므로 인덱스를 이용한 추출을 시도하고, 이 때 `StringIndexOutOfBoundsException`이 발생하게 됩니다. 본 PR에서는 빈 문자열일 경우에 대한 예외처리를 추가하여 해당 이슈를 해결하는 내용을 담고 있습니다.
