### PR TITLE
[HOTFIX] SlackMessageRequest DTO 분할

### DIFF
--- a/src/main/java/kr/hs/entrydsm/husky/domain/pdf/service/PDFExportServiceImpl.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/pdf/service/PDFExportServiceImpl.java
@@ -91,7 +91,6 @@ public class PDFExportServiceImpl implements PDFExportService {
 
             ByteArrayOutputStream result = new ByteArrayOutputStream();
             Docx4J.toFO(settings, result, Docx4J.FLAG_EXPORT_PREFER_NONXSL);
-
             return result.toByteArray();
 
         } catch (Exception e) {

--- a/src/main/java/kr/hs/entrydsm/husky/global/slack/SlackMessageRequest.java
+++ b/src/main/java/kr/hs/entrydsm/husky/global/slack/SlackMessageRequest.java
@@ -1,37 +1,18 @@
 package kr.hs.entrydsm.husky.global.slack;
 
+import kr.hs.entrydsm.husky.global.slack.dto.Attachment;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 
+@Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class SlackMessageRequest {
     private List<Attachment> attachments;
-}
-
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-class Attachment {
-    private String color;
-    private String pretext;
-    private String authorName;
-    private String title;
-    private String text;
-    private String footer;
-    private Long ts;
-    private List<Field> fields;
-}
-
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-class Field {
-    private String title;
-    private String value;
 }

--- a/src/main/java/kr/hs/entrydsm/husky/global/slack/SlackSenderManager.java
+++ b/src/main/java/kr/hs/entrydsm/husky/global/slack/SlackSenderManager.java
@@ -3,6 +3,8 @@ package kr.hs.entrydsm.husky.global.slack;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import kr.hs.entrydsm.husky.global.slack.dto.Attachment;
+import kr.hs.entrydsm.husky.global.slack.dto.Field;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/kr/hs/entrydsm/husky/global/slack/dto/Attachment.java
+++ b/src/main/java/kr/hs/entrydsm/husky/global/slack/dto/Attachment.java
@@ -1,0 +1,23 @@
+package kr.hs.entrydsm.husky.global.slack.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Attachment {
+    private String color;
+    private String pretext;
+    private String authorName;
+    private String title;
+    private String text;
+    private String footer;
+    private Long ts;
+    private List<Field> fields;
+}

--- a/src/main/java/kr/hs/entrydsm/husky/global/slack/dto/Field.java
+++ b/src/main/java/kr/hs/entrydsm/husky/global/slack/dto/Field.java
@@ -1,0 +1,15 @@
+package kr.hs.entrydsm.husky.global.slack.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Field {
+    private String title;
+    private String value;
+}


### PR DESCRIPTION
# SlackMessageRequest DTO 분할
## 목적
### 요약
`SlackMessageRequest` 분할 및 Getter 메서드 추가

### 상세
이전 PR을 수정할 때 Getter 메서드를 전부 삭제해 버리는 바람에 ObjectMapper를 호출할 때마다 필드를 가져올 수 없는 오류가 발생했습니다. 본 PR은 이를 수정 작업한 것입니다.
