### PR TITLE
Email param to Email body

### DIFF
--- a/src/main/java/kr/hs/entrydsm/husky/domain/auth/controllers/AuthController.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/auth/controllers/AuthController.java
@@ -1,6 +1,7 @@
 package kr.hs.entrydsm.husky.domain.auth.controllers;
 
 import kr.hs.entrydsm.husky.domain.auth.dto.request.AccountRequest;
+import kr.hs.entrydsm.husky.domain.auth.dto.request.EmailRequest;
 import kr.hs.entrydsm.husky.domain.auth.dto.request.VerifyCodeRequest;
 import kr.hs.entrydsm.husky.domain.auth.dto.request.ChangePasswordRequest;
 import kr.hs.entrydsm.husky.domain.auth.service.user.UserServiceImpl;
@@ -23,8 +24,8 @@ public class AuthController {
     }
 
     @PostMapping("/email/verify")
-    public void sendEmail(@RequestParam("email") @Email String email) {
-        userService.sendSignUpEmail(email);
+    public void sendEmail(@RequestBody EmailRequest emailRequest) {
+        userService.sendSignUpEmail(emailRequest);
     }
 
     @PutMapping("/email/verify")
@@ -33,8 +34,8 @@ public class AuthController {
     }
 
     @PostMapping("/email/password/verify")
-    public void sendPasswordChangeEmail(@RequestParam("email") @Email String email) {
-        userService.sendPasswordChangeEmail(email);
+    public void sendPasswordChangeEmail(@RequestBody EmailRequest emailRequest) {
+        userService.sendPasswordChangeEmail(emailRequest);
     }
 
     @PutMapping("/password")

--- a/src/main/java/kr/hs/entrydsm/husky/domain/auth/controllers/AuthController.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/auth/controllers/AuthController.java
@@ -24,7 +24,7 @@ public class AuthController {
     }
 
     @PostMapping("/email/verify")
-    public void sendEmail(@RequestBody EmailRequest emailRequest) {
+    public void sendEmail(@RequestBody @Valid EmailRequest emailRequest) {
         userService.sendSignUpEmail(emailRequest);
     }
 
@@ -34,7 +34,7 @@ public class AuthController {
     }
 
     @PostMapping("/email/password/verify")
-    public void sendPasswordChangeEmail(@RequestBody EmailRequest emailRequest) {
+    public void sendPasswordChangeEmail(@RequestBody @Valid EmailRequest emailRequest) {
         userService.sendPasswordChangeEmail(emailRequest);
     }
 

--- a/src/main/java/kr/hs/entrydsm/husky/domain/auth/dto/request/EmailRequest.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/auth/dto/request/EmailRequest.java
@@ -1,0 +1,17 @@
+package kr.hs.entrydsm.husky.domain.auth.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.Email;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class EmailRequest {
+
+    @Email
+    private String email;
+
+}

--- a/src/main/java/kr/hs/entrydsm/husky/domain/auth/service/user/UserService.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/auth/service/user/UserService.java
@@ -2,12 +2,13 @@ package kr.hs.entrydsm.husky.domain.auth.service.user;
 
 import kr.hs.entrydsm.husky.domain.auth.dto.request.AccountRequest;
 import kr.hs.entrydsm.husky.domain.auth.dto.request.ChangePasswordRequest;
+import kr.hs.entrydsm.husky.domain.auth.dto.request.EmailRequest;
 import kr.hs.entrydsm.husky.domain.auth.dto.request.VerifyCodeRequest;
 
 public interface UserService {
     void signUp(AccountRequest accountRequest);
-    void sendSignUpEmail(String email);
+    void sendSignUpEmail(EmailRequest emailRequest);
     void authEmail(VerifyCodeRequest verifyCodeRequest);
-    void sendPasswordChangeEmail(String email);
+    void sendPasswordChangeEmail(EmailRequest emailRequest);
     void changePassword(ChangePasswordRequest changePasswordRequest);
 }

--- a/src/main/java/kr/hs/entrydsm/husky/domain/auth/service/user/UserServiceImpl.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/auth/service/user/UserServiceImpl.java
@@ -2,6 +2,7 @@ package kr.hs.entrydsm.husky.domain.auth.service.user;
 
 import kr.hs.entrydsm.husky.domain.auth.dto.request.AccountRequest;
 import kr.hs.entrydsm.husky.domain.auth.dto.request.ChangePasswordRequest;
+import kr.hs.entrydsm.husky.domain.auth.dto.request.EmailRequest;
 import kr.hs.entrydsm.husky.domain.auth.dto.request.VerifyCodeRequest;
 import kr.hs.entrydsm.husky.domain.auth.domain.verification.EmailVerification;
 import kr.hs.entrydsm.husky.domain.auth.domain.verification.EmailVerificationRepository;
@@ -53,7 +54,8 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public void sendSignUpEmail(String email) {
+    public void sendSignUpEmail(EmailRequest emailRequest) {
+        String email = emailRequest.getEmail();
         userRepository.findByEmail(email)
                 .ifPresent(user -> {
                     throw new UserAlreadyExistsException();
@@ -85,7 +87,8 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public void sendPasswordChangeEmail(String email) {
+    public void sendPasswordChangeEmail(EmailRequest emailRequest) {
+        String email = emailRequest.getEmail();
         userRepository.findByEmail(email)
                 .orElseThrow(UserNotFoundException::new);
 


### PR DESCRIPTION
# Email param to Email body
## 목적
### 요약
이메일 받는 방식 변경
### 상세
기존에 이메일을 파라미터로 받는것을 body로 받게 변경 했습니다.
## 영향을 미치는 부분
이메일 서비스와 구현 클래스의 인자값이 변경됩니다.
api명세가 변경됩니다