### PR TITLE
Fix school search

### DIFF
--- a/src/main/java/kr/hs/entrydsm/husky/domain/application/domain/GeneralApplication.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/application/domain/GeneralApplication.java
@@ -113,7 +113,7 @@ public abstract class GeneralApplication extends BaseTimeEntity {
     }
 
     public boolean isFilledStudentInfo() {
-        return studentNumber != null && school != null && schoolTel != null;
+        return isExists(studentNumber) && school != null && isExists(schoolTel);
     }
 
     public boolean isSchoolEmpty() {

--- a/src/main/java/kr/hs/entrydsm/husky/domain/image/service/ImageService.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/image/service/ImageService.java
@@ -10,5 +10,6 @@ public interface ImageService {
     String upload(MultipartFile file) throws IOException;
     String generateObjectUrl(String objectName) throws MalformedURLException;
     byte[] getObject(String fileName) throws IOException;
+    void delete(String objectName);
 
 }

--- a/src/main/java/kr/hs/entrydsm/husky/domain/image/service/S3ImageServiceImpl.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/image/service/S3ImageServiceImpl.java
@@ -37,7 +37,6 @@ public class S3ImageServiceImpl extends AWS4Signer implements ImageService {
     private static final Integer EXPIRES = 900;
 
     private final SimpleDateFormat dateTimeFormat = new SimpleDateFormat(ISO8601BasicFormat);
-
     private final SimpleDateFormat dateStampFormat = new SimpleDateFormat("yyyyMMdd");
 
     private final AmazonS3 s3;
@@ -60,7 +59,7 @@ public class S3ImageServiceImpl extends AWS4Signer implements ImageService {
     @Override
     public String upload(MultipartFile file) throws IOException {
         String originalFilename = file.getOriginalFilename();
-        String ext = originalFilename.substring( originalFilename.lastIndexOf(".") + 1);
+        String ext = originalFilename.substring(originalFilename.lastIndexOf(".") + 1);
         String randomName = UUID.randomUUID().toString();
         String filename = randomName + "." + ext;
 

--- a/src/main/java/kr/hs/entrydsm/husky/domain/image/service/S3ImageServiceImpl.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/image/service/S3ImageServiceImpl.java
@@ -36,9 +36,9 @@ public class S3ImageServiceImpl extends AWS4Signer implements ImageService {
 
     private static final Integer EXPIRES = 900;
 
-    private SimpleDateFormat dateTimeFormat = new SimpleDateFormat(ISO8601BasicFormat);
+    private final SimpleDateFormat dateTimeFormat = new SimpleDateFormat(ISO8601BasicFormat);
 
-    private SimpleDateFormat dateStampFormat = new SimpleDateFormat("yyyyMMdd");
+    private final SimpleDateFormat dateStampFormat = new SimpleDateFormat("yyyyMMdd");
 
     private final AmazonS3 s3;
 
@@ -68,6 +68,11 @@ public class S3ImageServiceImpl extends AWS4Signer implements ImageService {
                 .withCannedAcl(CannedAccessControlList.AuthenticatedRead));
 
         return filename;
+    }
+
+    @Override
+    public void delete(String objectName) {
+        s3.deleteObject(bucket, objectName);
     }
 
     @Override

--- a/src/main/java/kr/hs/entrydsm/husky/domain/process/service/ProcessServiceImpl.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/process/service/ProcessServiceImpl.java
@@ -12,6 +12,8 @@ import kr.hs.entrydsm.husky.global.config.security.AuthenticationFacade;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import static kr.hs.entrydsm.husky.global.util.Validator.isExists;
+
 @RequiredArgsConstructor
 @Service
 public class ProcessServiceImpl implements ProcessService {
@@ -83,7 +85,7 @@ public class ProcessServiceImpl implements ProcessService {
     }
 
     private boolean checkDocs(User user) {
-        return user.getSelfIntroduction() != null && user.getStudyPlan() != null;
+        return isExists(user.getSelfIntroduction()) && isExists(user.getStudyPlan());
     }
 
     public boolean AllCheck(User user) {

--- a/src/main/java/kr/hs/entrydsm/husky/domain/school/controller/SchoolController.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/school/controller/SchoolController.java
@@ -19,10 +19,9 @@ public class SchoolController {
     private final SchoolService schoolService;
 
     @GetMapping("/schools")
-    public Page<School> search(@RequestParam @NotBlank String eduOffice,
-                               @RequestParam @NotBlank String name,
+    public Page<School> search(@RequestParam @NotBlank String name,
                                Pageable pageable) {
-        return schoolService.search(eduOffice, name, pageable);
+        return schoolService.search(name, pageable);
     }
 
     @ExceptionHandler(MissingServletRequestParameterException.class)

--- a/src/main/java/kr/hs/entrydsm/husky/domain/school/domain/repositories/SchoolRepository.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/school/domain/repositories/SchoolRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SchoolRepository extends JpaRepository<School, String> {
-    Page<School> findBySchoolFullNameContainsAndSchoolNameContains(String region, String name, Pageable pageable);
+    Page<School> findBySchoolFullNameContains(String name, Pageable pageable);
 }

--- a/src/main/java/kr/hs/entrydsm/husky/domain/school/service/SchoolService.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/school/service/SchoolService.java
@@ -6,6 +6,6 @@ import org.springframework.data.domain.Pageable;
 
 public interface SchoolService {
 
-    Page<School> search(String eduOffice, String name, Pageable pageable);
+    Page<School> search(String name, Pageable pageable);
 
 }

--- a/src/main/java/kr/hs/entrydsm/husky/domain/school/service/SchoolServiceImpl.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/school/service/SchoolServiceImpl.java
@@ -14,8 +14,8 @@ public class SchoolServiceImpl implements SchoolService {
     private final SchoolRepository schoolRepository;
 
     @Override
-    public Page<School> search(String eduOffice, String name, Pageable pageable) {
-        return schoolRepository.findBySchoolFullNameContainsAndSchoolNameContains(eduOffice, name, pageable);
+    public Page<School> search(String name, Pageable pageable) {
+        return schoolRepository.findBySchoolFullNameContains(name, pageable);
     }
 
 }

--- a/src/main/java/kr/hs/entrydsm/husky/domain/user/service/info/UserInfoServiceImpl.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/user/service/info/UserInfoServiceImpl.java
@@ -22,6 +22,8 @@ import org.springframework.stereotype.Service;
 import javax.transaction.Transactional;
 import java.net.MalformedURLException;
 
+import static kr.hs.entrydsm.husky.global.util.Validator.isExists;
+
 @RequiredArgsConstructor
 @Service
 public class UserInfoServiceImpl implements UserInfoService {
@@ -43,7 +45,8 @@ public class UserInfoServiceImpl implements UserInfoService {
         User user = userRepository.findById(receiptCode)
                 .orElseThrow(UserNotFoundException::new);
 
-        if(!user.getUserPhoto().isEmpty() && request.getPhoto() != null) deleteLastPhoto(user);
+        if (!user.isPhotoEmpty() && isExists(request.getPhoto()))
+            imageService.delete(user.getUserPhoto());
 
         user.updateInfo(request);
         userAsyncRepository.save(user);
@@ -75,10 +78,6 @@ public class UserInfoServiceImpl implements UserInfoService {
 
     private String getImageUrl(User user) throws MalformedURLException {
         return (!user.isPhotoEmpty()) ? imageService.generateObjectUrl(user.getUserPhoto()) : null;
-    }
-
-    private void deleteLastPhoto(User user) {
-        imageService.delete(user.getUserPhoto());
     }
 
     @Override

--- a/src/main/java/kr/hs/entrydsm/husky/domain/user/service/info/UserInfoServiceImpl.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/user/service/info/UserInfoServiceImpl.java
@@ -43,6 +43,8 @@ public class UserInfoServiceImpl implements UserInfoService {
         User user = userRepository.findById(receiptCode)
                 .orElseThrow(UserNotFoundException::new);
 
+        if(!user.getUserPhoto().isEmpty() && request.getPhoto() != null) deleteLastPhoto(user);
+
         user.updateInfo(request);
         userAsyncRepository.save(user);
 
@@ -73,6 +75,10 @@ public class UserInfoServiceImpl implements UserInfoService {
 
     private String getImageUrl(User user) throws MalformedURLException {
         return (!user.isPhotoEmpty()) ? imageService.generateObjectUrl(user.getUserPhoto()) : null;
+    }
+
+    private void deleteLastPhoto(User user) {
+        imageService.delete(user.getUserPhoto());
     }
 
     @Override


### PR DESCRIPTION
# Fix school search
## 목적
### 요약
* Validation 강화
* 학교 API 수정
* 기존 이미지 삭제
### 상세
`Validation 강화`
isFilledStudentInfo() 메소드와 checkDocs(User user) 메소드의 Validation 강화. Blank(빈 문자열)도 검증
`학교 API 수정`
eduOffice(교육청) 파라미터 제거 및 find method 수정
`프로필 이미지 변경 시 기존 이미지 삭제`
s3 delete method 추가 및 service 로직에 적용
## 영향을 미치는 부분
학교 검색을 사용하는 Entry Main
## 참조(선택)
#51 , #56 , #63 
