### PR TITLE
Fix validation

### DIFF
--- a/src/main/java/kr/hs/entrydsm/husky/domain/grade/service/GradeCalcServiceImpl.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/grade/service/GradeCalcServiceImpl.java
@@ -158,7 +158,7 @@ public class GradeCalcServiceImpl implements GradeCalcService {
         BigDecimal secondGradeScore = null;
         BigDecimal thirdGradeScore;
 
-        if (matrixUtil.isAllGradeEmpty() || matrixUtil.isThirdGradeEmpty(user.getGradeType()))
+        if (matrixUtil.isAllGradeEmpty() || matrixUtil.isThirdGradeEmpty())
             return GradeScore.EMPTY();
 
         boolean isFirstGradeEmpty = matrixUtil.isFirstGradeEmpty();

--- a/src/main/java/kr/hs/entrydsm/husky/domain/grade/service/GradeCalcServiceImpl.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/grade/service/GradeCalcServiceImpl.java
@@ -158,7 +158,7 @@ public class GradeCalcServiceImpl implements GradeCalcService {
         BigDecimal secondGradeScore = null;
         BigDecimal thirdGradeScore;
 
-        if (matrixUtil.isAllGradeEmpty() || matrixUtil.isThirdGradeEmpty())
+        if (matrixUtil.isAllGradeEmpty() || matrixUtil.isThirdGradeEmpty(user.getGradeType()))
             return GradeScore.EMPTY();
 
         boolean isFirstGradeEmpty = matrixUtil.isFirstGradeEmpty();

--- a/src/main/java/kr/hs/entrydsm/husky/domain/grade/util/GradeUtil.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/grade/util/GradeUtil.java
@@ -31,8 +31,18 @@ public class GradeUtil {
         return isEmptyGrade(SEMESTER_2_1, SEMESTER_2_2);
     }
 
-    public boolean isThirdGradeEmpty() {
-        return isEmptyGrade(SEMESTER_3_1);
+    public boolean isThirdGradeEmpty(GradeType gradeType) {
+        switch (gradeType) {
+            case UNGRADUATED:
+                return isEmptyGrade(SEMESTER_3_1);
+
+            case GRADUATED:
+                return isEmptyGrade(SEMESTER_3_1, SEMESTER_3_2);
+
+            default:
+                return true;
+        }
+
     }
 
     public boolean isAllGradeEmpty() {

--- a/src/main/java/kr/hs/entrydsm/husky/domain/grade/util/GradeUtil.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/grade/util/GradeUtil.java
@@ -31,17 +31,8 @@ public class GradeUtil {
         return isEmptyGrade(SEMESTER_2_1, SEMESTER_2_2);
     }
 
-    public boolean isThirdGradeEmpty(GradeType gradeType) {
-        switch (gradeType) {
-            case GRADUATED:
-                return isEmptyGrade(SEMESTER_3_1, SEMESTER_3_2);
-
-            case UNGRADUATED:
-                return isEmptyGrade(SEMESTER_3_1);
-
-            default:
-                return true;
-        }
+    public boolean isThirdGradeEmpty() {
+        return isEmptyGrade(SEMESTER_3_1);
     }
 
     public boolean isAllGradeEmpty() {

--- a/src/main/java/kr/hs/entrydsm/husky/domain/process/service/ProcessService.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/process/service/ProcessService.java
@@ -1,9 +1,11 @@
 package kr.hs.entrydsm.husky.domain.process.service;
 
 import kr.hs.entrydsm.husky.domain.process.dto.ProcessResponse;
+import kr.hs.entrydsm.husky.domain.user.domain.User;
 
 public interface ProcessService {
 
     ProcessResponse getProcess();
+    boolean AllCheck(User user);
 
 }

--- a/src/main/java/kr/hs/entrydsm/husky/domain/process/service/ProcessService.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/process/service/ProcessService.java
@@ -1,11 +1,12 @@
 package kr.hs.entrydsm.husky.domain.process.service;
 
+import kr.hs.entrydsm.husky.domain.application.domain.CalculatedScore;
 import kr.hs.entrydsm.husky.domain.process.dto.ProcessResponse;
 import kr.hs.entrydsm.husky.domain.user.domain.User;
 
 public interface ProcessService {
 
     ProcessResponse getProcess();
-    boolean AllCheck(User user);
+    boolean allCheck(User user, CalculatedScore score);
 
 }

--- a/src/main/java/kr/hs/entrydsm/husky/domain/process/service/ProcessServiceImpl.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/process/service/ProcessServiceImpl.java
@@ -44,6 +44,12 @@ public class ProcessServiceImpl implements ProcessService {
                 .build();
     }
 
+    @Override
+    public boolean allCheck(User user, CalculatedScore score) {
+        return checkType(user) && checkDocs(user) && checkInfo(user) && checkScore(user) &&
+                checkConversionScore(user, score);
+    }
+
     private boolean checkType(User user) {
         if (user.isGED()) {
             return gedApplicationRepository.findById(user.getReceiptCode())
@@ -78,7 +84,6 @@ public class ProcessServiceImpl implements ProcessService {
 
     private boolean checkScore(User user) {
         if (!checkType(user)) return false;
-        if (!checkConversionScore(user)) return false;
 
         if (user.isGED()) {
             return gedApplicationRepository.findById(user.getReceiptCode())
@@ -94,10 +99,8 @@ public class ProcessServiceImpl implements ProcessService {
         return isExists(user.getSelfIntroduction()) && isExists(user.getStudyPlan());
     }
 
-    private boolean checkConversionScore(User user) {
+    private boolean checkConversionScore(User user, CalculatedScore score) {
         if (scoreRepository.findById(user.getReceiptCode()).isEmpty()) return false;
-
-        CalculatedScore score = scoreRepository.findById(user.getReceiptCode()).get();
 
         if (user.isGED()) {
             return isEqualTo(score.getAttendanceScore(), 15) &&
@@ -114,11 +117,6 @@ public class ProcessServiceImpl implements ProcessService {
                 isPositive(score.getSecondGradeScore()) &&
                 isPositive(score.getThirdGradeScore()) &&
                 isPositive(score.getConversionScore());
-    }
-
-    @Override
-    public boolean AllCheck(User user) {
-        return checkType(user) && checkDocs(user) && checkInfo(user) && checkScore(user);
     }
 
 }

--- a/src/main/java/kr/hs/entrydsm/husky/domain/process/service/ProcessServiceImpl.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/process/service/ProcessServiceImpl.java
@@ -95,17 +95,25 @@ public class ProcessServiceImpl implements ProcessService {
     }
 
     private boolean checkConversionScore(User user) {
-        if(scoreRepository.findById(user.getReceiptCode()).isPresent()) {
-            CalculatedScore score = scoreRepository.findById(user.getReceiptCode()).get();
+        if (scoreRepository.findById(user.getReceiptCode()).isEmpty()) return false;
 
-            return isGreaterThanOrEqualTo(score.getAttendanceScore(), 0) &&
+        CalculatedScore score = scoreRepository.findById(user.getReceiptCode()).get();
+
+        if (user.isGED()) {
+            return isEqualTo(score.getAttendanceScore(), 15) &&
                     isGreaterThanOrEqualTo(score.getVolunteerScore(), BigDecimal.valueOf(3)) &&
-                    isNotZero(score.getFirstGradeScore()) &&
-                    isNotZero(score.getSecondGradeScore()) &&
-                    isNotZero(score.getThirdGradeScore()) &&
+                    isZero(score.getFirstGradeScore()) &&
+                    isZero(score.getSecondGradeScore()) &&
+                    isZero(score.getThirdGradeScore()) &&
                     isNotZero(score.getConversionScore());
         }
-        return false;
+
+        return isGreaterThanOrEqualTo(score.getAttendanceScore(), 0) &&
+                isGreaterThanOrEqualTo(score.getVolunteerScore(), BigDecimal.valueOf(3)) &&
+                isNotZero(score.getFirstGradeScore()) &&
+                isNotZero(score.getSecondGradeScore()) &&
+                isNotZero(score.getThirdGradeScore()) &&
+                isNotZero(score.getConversionScore());
     }
 
     @Override

--- a/src/main/java/kr/hs/entrydsm/husky/domain/process/service/ProcessServiceImpl.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/process/service/ProcessServiceImpl.java
@@ -105,15 +105,15 @@ public class ProcessServiceImpl implements ProcessService {
                     isZero(score.getFirstGradeScore()) &&
                     isZero(score.getSecondGradeScore()) &&
                     isZero(score.getThirdGradeScore()) &&
-                    isNotZero(score.getConversionScore());
+                    isPositive(score.getConversionScore());
         }
 
         return isGreaterThanOrEqualTo(score.getAttendanceScore(), 0) &&
                 isGreaterThanOrEqualTo(score.getVolunteerScore(), BigDecimal.valueOf(3)) &&
-                isNotZero(score.getFirstGradeScore()) &&
-                isNotZero(score.getSecondGradeScore()) &&
-                isNotZero(score.getThirdGradeScore()) &&
-                isNotZero(score.getConversionScore());
+                isPositive(score.getFirstGradeScore()) &&
+                isPositive(score.getSecondGradeScore()) &&
+                isPositive(score.getThirdGradeScore()) &&
+                isPositive(score.getConversionScore());
     }
 
     @Override

--- a/src/main/java/kr/hs/entrydsm/husky/domain/process/service/ProcessServiceImpl.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/process/service/ProcessServiceImpl.java
@@ -26,7 +26,6 @@ public class ProcessServiceImpl implements ProcessService {
     private final GEDApplicationRepository gedApplicationRepository;
     private final GeneralApplicationRepository generalApplicationRepository;
     private final GraduatedApplicationRepository graduatedApplicationRepository;
-    private final CalculatedScoreRepository scoreRepository;
 
     private final AuthenticationFacade authenticationFacade;
 
@@ -100,8 +99,6 @@ public class ProcessServiceImpl implements ProcessService {
     }
 
     private boolean checkConversionScore(User user, CalculatedScore score) {
-        if (scoreRepository.findById(user.getReceiptCode()).isEmpty()) return false;
-
         if (user.isGED()) {
             return isEqualTo(score.getAttendanceScore(), 15) &&
                     isGreaterThanOrEqualTo(score.getVolunteerScore(), BigDecimal.valueOf(3)) &&

--- a/src/main/java/kr/hs/entrydsm/husky/domain/user/service/status/UserStatusServiceImpl.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/user/service/status/UserStatusServiceImpl.java
@@ -1,5 +1,6 @@
 package kr.hs.entrydsm.husky.domain.user.service.status;
 
+import kr.hs.entrydsm.husky.domain.application.domain.CalculatedScore;
 import kr.hs.entrydsm.husky.domain.grade.service.GradeCalcService;
 import kr.hs.entrydsm.husky.domain.process.service.ProcessService;
 import kr.hs.entrydsm.husky.domain.user.dto.UserStatusResponse;
@@ -46,9 +47,9 @@ public class UserStatusServiceImpl implements UserStatusService {
         Status status = statusRepository.findById(receiptCode)
                 .orElseGet(() -> statusRepository.save(new Status(receiptCode)));
 
-        gradeCalcService.calcStudentGrade(user);
+        CalculatedScore score = gradeCalcService.calcStudentGrade(user);
 
-        if (!processService.AllCheck(user))
+        if (!processService.allCheck(user, score))
             throw new NotCompletedProcessException();
 
         status.finalSubmit();

--- a/src/main/java/kr/hs/entrydsm/husky/domain/user/service/status/UserStatusServiceImpl.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/user/service/status/UserStatusServiceImpl.java
@@ -1,6 +1,7 @@
 package kr.hs.entrydsm.husky.domain.user.service.status;
 
-import kr.hs.entrydsm.husky.domain.process.service.ProcessServiceImpl;
+import kr.hs.entrydsm.husky.domain.grade.service.GradeCalcService;
+import kr.hs.entrydsm.husky.domain.process.service.ProcessService;
 import kr.hs.entrydsm.husky.domain.user.dto.UserStatusResponse;
 import kr.hs.entrydsm.husky.domain.user.exception.NotCompletedProcessException;
 import kr.hs.entrydsm.husky.domain.user.exception.UserNotFoundException;
@@ -21,7 +22,8 @@ public class UserStatusServiceImpl implements UserStatusService {
     private final UserRepository userRepository;
     private final StatusRepository statusRepository;
 
-    private final ProcessServiceImpl processService;
+    private final ProcessService processService;
+    private final GradeCalcService gradeCalcService;
 
     @Override
     public UserStatusResponse getStatus() {
@@ -43,6 +45,8 @@ public class UserStatusServiceImpl implements UserStatusService {
 
         Status status = statusRepository.findById(receiptCode)
                 .orElseGet(() -> statusRepository.save(new Status(receiptCode)));
+
+        gradeCalcService.calcStudentGrade(user);
 
         if (!processService.AllCheck(user))
             throw new NotCompletedProcessException();

--- a/src/main/java/kr/hs/entrydsm/husky/global/util/Validator.java
+++ b/src/main/java/kr/hs/entrydsm/husky/global/util/Validator.java
@@ -1,13 +1,22 @@
 package kr.hs.entrydsm.husky.global.util;
 
+import java.math.BigDecimal;
+
 public class Validator {
-    public static boolean isBlank(String target) {
-        return target == null || target.isBlank();
+    public static boolean isExists(String target) {
+        return (target != null) && (!target.isBlank());
     }
 
-    public static boolean isExists(String target) {
-        if (target == null) return false;
-        return !target.isBlank();
+    public static boolean isGreaterThanOrEqualTo(Integer target, Integer standard) {
+        return (target != null) && (target >= standard);
+    }
+
+    public static boolean isGreaterThanOrEqualTo(BigDecimal target, BigDecimal standard) {
+        return (target != null) && (target.compareTo(standard) >= 0);
+    }
+
+    public static boolean isNotZero(BigDecimal target) {
+        return (target != null) && (!target.equals(BigDecimal.ZERO));
     }
 
 }

--- a/src/main/java/kr/hs/entrydsm/husky/global/util/Validator.java
+++ b/src/main/java/kr/hs/entrydsm/husky/global/util/Validator.java
@@ -15,8 +15,16 @@ public class Validator {
         return (target != null) && (target.compareTo(standard) >= 0);
     }
 
+    public static boolean isEqualTo(Integer target, Integer standard) {
+        return (target != null) && (target.equals(standard));
+    }
+
     public static boolean isNotZero(BigDecimal target) {
         return (target != null) && (!target.equals(BigDecimal.ZERO));
+    }
+
+    public static boolean isZero(BigDecimal target) {
+        return (target != null) && (target.equals(BigDecimal.ZERO));
     }
 
 }

--- a/src/main/java/kr/hs/entrydsm/husky/global/util/Validator.java
+++ b/src/main/java/kr/hs/entrydsm/husky/global/util/Validator.java
@@ -19,8 +19,8 @@ public class Validator {
         return (target != null) && (target.equals(standard));
     }
 
-    public static boolean isNotZero(BigDecimal target) {
-        return (target != null) && (!target.equals(BigDecimal.ZERO));
+    public static boolean isPositive(BigDecimal target) {
+        return (target != null) && (target.compareTo(BigDecimal.ZERO) > 0);
     }
 
     public static boolean isZero(BigDecimal target) {


### PR DESCRIPTION
# Fix Validation
## 목적
### 요약
최종제출 시 성적 환산 처리 및 환산 점수 검증
### 상세
* ValidationMethod 추가(`isGraterThanOrEqualTo`, `isNotZero`)
* GradeUtil의 `isThirdGradeEmpty`에서 GradeType에 상관없이 3학년 1학기 성적만 검증하도록 변경
* ProcessServiceImpl에 `checkConversionScore` 메서드 추가 및 적용
## 참조(선택)
#69 
