### PR TITLE
CSRF protect 설정 적용

### DIFF
--- a/src/main/java/kr/hs/entrydsm/husky/global/config/security/SecurityConfig.java
+++ b/src/main/java/kr/hs/entrydsm/husky/global/config/security/SecurityConfig.java
@@ -11,6 +11,7 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 
 @Configuration
 @EnableWebSecurity
@@ -29,8 +30,6 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http
-                .csrf().disable()
-                .formLogin().disable()
                 .headers()
                     .frameOptions()
                     .disable().and()
@@ -45,6 +44,10 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                     .antMatchers("/actuator/health").permitAll()
                     .antMatchers("/schedules").permitAll()
                     .anyRequest().authenticated().and()
+                .csrf()
+                    .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse()).and()
+                .formLogin()
+                    .disable()
                 .apply(new JwtConfigurer(jwtTokenProvider)).and()
                 .apply(new ExceptionConfigurer(slackSenderManager));
     }


### PR DESCRIPTION
# CSRF protect 설정 적용
## 목적
### 요약
* CSRF 공격 방어를 위한 설정 적용
* CSRF 쿠키 설정 동작 로컬 테스트
### 상세
`CSRF 공격 방어를 위한 설정 적용`
**SecurityConfig**에서 Cookie로 Token을 전달하는 설정을 적용함.
`CSRF 쿠키 설정 동작 로컬 테스트`
로컬 테스트를 통해 GET 요청에서 `XSRF-TOKEN` 쿠키 값이 제대로 전달되는 지 확인했으며,
쿠키 안의 토큰 값을 `X-XSRF-TOKEN` 헤더에 넣어 요청하여 성공하는 지 확인했다. 헤더를 보내지 않거나 토큰이 유효하지 않다면 `403 FORBIDDEN` 처리된다.
## 영향을 미치는 부분
프론트엔드에서 GET이외의 요청 시 `XSRF-TOKEN` 쿠키 값을 `X-XSRF-TOKEN` 헤더에 넣어서 보내야 한다. 그렇지 않을 경우 `403 FORBIDDEN` 처리됨. 이것을 프론트 팀에게 전달하고 반영해야 한다.
## 참조(선택)
연관된 이슈 번호들
