### PR TITLE
GET Status API 분리

### DIFF
--- a/src/main/java/kr/hs/entrydsm/husky/domain/user/controller/UserInfoController.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/user/controller/UserInfoController.java
@@ -65,6 +65,9 @@ public class UserInfoController {
         return userStatusService.finalSubmit();
     }
 
+    @GetMapping("/status/pass")
+    public UserPassResponse getUserPassStatus() { return userStatusService.isPassed(); }
+
     @PostMapping("/photo")
     @ResponseStatus(value = HttpStatus.CREATED)
     public String uploadPhoto(@RequestPart MultipartFile file) throws Exception {

--- a/src/main/java/kr/hs/entrydsm/husky/domain/user/controller/UserInfoController.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/user/controller/UserInfoController.java
@@ -65,8 +65,11 @@ public class UserInfoController {
         return userStatusService.finalSubmit();
     }
 
-    @GetMapping("/status/pass")
-    public UserPassResponse getUserPassStatus() { return userStatusService.isPassed(); }
+    @GetMapping("/pass/first")
+    public UserPassResponse isPassedFirst() { return userStatusService.isPassedFirst(); }
+
+    @GetMapping("/pass/final")
+    public UserPassResponse isPassedFinal() { return userStatusService.isPassedFinal(); }
 
     @PostMapping("/photo")
     @ResponseStatus(value = HttpStatus.CREATED)

--- a/src/main/java/kr/hs/entrydsm/husky/domain/user/dto/UserPassResponse.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/user/dto/UserPassResponse.java
@@ -1,0 +1,17 @@
+package kr.hs.entrydsm.husky.domain.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserPassResponse {
+
+    private boolean isPassedFirstApply;
+    private boolean isPassedInterview;
+
+}

--- a/src/main/java/kr/hs/entrydsm/husky/domain/user/dto/UserPassResponse.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/user/dto/UserPassResponse.java
@@ -11,7 +11,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class UserPassResponse {
 
-    private boolean isPassedFirstApply;
-    private boolean isPassedInterview;
+    private boolean isPassed;
 
 }

--- a/src/main/java/kr/hs/entrydsm/husky/domain/user/dto/UserStatusResponse.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/user/dto/UserStatusResponse.java
@@ -21,8 +21,6 @@ public class UserStatusResponse {
     private boolean isFinalSubmit;
     private boolean isPaid;
     private boolean isPrintedApplicationArrived;
-    private boolean isPassedFirstApply;
-    private boolean isPassedInterview;
     private LocalDateTime submittedAt;
 
     public static UserStatusResponse response(User user, Status status) {
@@ -32,8 +30,6 @@ public class UserStatusResponse {
                 .isFinalSubmit(status.isFinalSubmit())
                 .isPaid(status.isPaid())
                 .isPrintedApplicationArrived(status.isPrintedApplicationArrived())
-                .isPassedFirstApply(status.isPassedFirstApply())
-                .isPassedInterview(status.isPassedInterview())
                 .submittedAt(status.getSubmittedAt())
                 .build();
     }

--- a/src/main/java/kr/hs/entrydsm/husky/domain/user/exception/NotStartedScheduleException.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/user/exception/NotStartedScheduleException.java
@@ -1,0 +1,8 @@
+package kr.hs.entrydsm.husky.domain.user.exception;
+
+import kr.hs.entrydsm.husky.global.error.exception.BusinessException;
+import kr.hs.entrydsm.husky.global.error.exception.ErrorCode;
+
+public class NotStartedScheduleException extends BusinessException {
+    public NotStartedScheduleException() { super(ErrorCode.NOT_STARTED_SCHEDULE); }
+}

--- a/src/main/java/kr/hs/entrydsm/husky/domain/user/exception/ProcessNotCompletedException.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/user/exception/ProcessNotCompletedException.java
@@ -3,8 +3,8 @@ package kr.hs.entrydsm.husky.domain.user.exception;
 import kr.hs.entrydsm.husky.global.error.exception.BusinessException;
 import kr.hs.entrydsm.husky.global.error.exception.ErrorCode;
 
-public class NotCompletedProcessException extends BusinessException {
-    public NotCompletedProcessException() {
+public class ProcessNotCompletedException extends BusinessException {
+    public ProcessNotCompletedException() {
         super(ErrorCode.NOT_COMPLETED_PROCESS);
     }
 }

--- a/src/main/java/kr/hs/entrydsm/husky/domain/user/exception/ProcessNotCompletedException.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/user/exception/ProcessNotCompletedException.java
@@ -5,6 +5,6 @@ import kr.hs.entrydsm.husky.global.error.exception.ErrorCode;
 
 public class ProcessNotCompletedException extends BusinessException {
     public ProcessNotCompletedException() {
-        super(ErrorCode.NOT_COMPLETED_PROCESS);
+        super(ErrorCode.PROCESS_NOT_COMPLETED);
     }
 }

--- a/src/main/java/kr/hs/entrydsm/husky/domain/user/exception/ScheduleNotFoundException.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/user/exception/ScheduleNotFoundException.java
@@ -1,0 +1,8 @@
+package kr.hs.entrydsm.husky.domain.user.exception;
+
+import kr.hs.entrydsm.husky.global.error.exception.BusinessException;
+import kr.hs.entrydsm.husky.global.error.exception.ErrorCode;
+
+public class ScheduleNotFoundException extends BusinessException {
+    public ScheduleNotFoundException() { super(ErrorCode.SCHEDULE_NOT_FOUND); }
+}

--- a/src/main/java/kr/hs/entrydsm/husky/domain/user/exception/ScheduleNotStartedException.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/user/exception/ScheduleNotStartedException.java
@@ -4,5 +4,5 @@ import kr.hs.entrydsm.husky.global.error.exception.BusinessException;
 import kr.hs.entrydsm.husky.global.error.exception.ErrorCode;
 
 public class ScheduleNotStartedException extends BusinessException {
-    public ScheduleNotStartedException() { super(ErrorCode.NOT_STARTED_SCHEDULE); }
+    public ScheduleNotStartedException() { super(ErrorCode.SCHEDULE_NOT_STARTED); }
 }

--- a/src/main/java/kr/hs/entrydsm/husky/domain/user/exception/ScheduleNotStartedException.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/user/exception/ScheduleNotStartedException.java
@@ -3,6 +3,6 @@ package kr.hs.entrydsm.husky.domain.user.exception;
 import kr.hs.entrydsm.husky.global.error.exception.BusinessException;
 import kr.hs.entrydsm.husky.global.error.exception.ErrorCode;
 
-public class NotStartedScheduleException extends BusinessException {
-    public NotStartedScheduleException() { super(ErrorCode.NOT_STARTED_SCHEDULE); }
+public class ScheduleNotStartedException extends BusinessException {
+    public ScheduleNotStartedException() { super(ErrorCode.NOT_STARTED_SCHEDULE); }
 }

--- a/src/main/java/kr/hs/entrydsm/husky/domain/user/service/status/UserStatusService.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/user/service/status/UserStatusService.java
@@ -7,6 +7,7 @@ public interface UserStatusService {
 
     UserStatusResponse getStatus();
     UserStatusResponse finalSubmit();
-    UserPassResponse isPassed();
+    UserPassResponse isPassedFirst();
+    UserPassResponse isPassedFinal();
 
 }

--- a/src/main/java/kr/hs/entrydsm/husky/domain/user/service/status/UserStatusService.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/user/service/status/UserStatusService.java
@@ -1,10 +1,12 @@
 package kr.hs.entrydsm.husky.domain.user.service.status;
 
+import kr.hs.entrydsm.husky.domain.user.dto.UserPassResponse;
 import kr.hs.entrydsm.husky.domain.user.dto.UserStatusResponse;
 
 public interface UserStatusService {
 
     UserStatusResponse getStatus();
     UserStatusResponse finalSubmit();
+    UserPassResponse isPassed();
 
 }

--- a/src/main/java/kr/hs/entrydsm/husky/domain/user/service/status/UserStatusServiceImpl.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/user/service/status/UserStatusServiceImpl.java
@@ -3,9 +3,13 @@ package kr.hs.entrydsm.husky.domain.user.service.status;
 import kr.hs.entrydsm.husky.domain.application.domain.CalculatedScore;
 import kr.hs.entrydsm.husky.domain.grade.service.GradeCalcService;
 import kr.hs.entrydsm.husky.domain.process.service.ProcessService;
+import kr.hs.entrydsm.husky.domain.schedule.dao.ScheduleRepository;
+import kr.hs.entrydsm.husky.domain.schedule.domain.Schedule;
 import kr.hs.entrydsm.husky.domain.user.dto.UserPassResponse;
 import kr.hs.entrydsm.husky.domain.user.dto.UserStatusResponse;
 import kr.hs.entrydsm.husky.domain.user.exception.NotCompletedProcessException;
+import kr.hs.entrydsm.husky.domain.user.exception.NotStartedScheduleException;
+import kr.hs.entrydsm.husky.domain.user.exception.ScheduleNotFoundException;
 import kr.hs.entrydsm.husky.domain.user.exception.UserNotFoundException;
 import kr.hs.entrydsm.husky.domain.user.domain.Status;
 import kr.hs.entrydsm.husky.domain.user.domain.User;
@@ -15,6 +19,9 @@ import kr.hs.entrydsm.husky.global.config.security.AuthenticationFacade;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+import java.util.Optional;
+
 @RequiredArgsConstructor
 @Service
 public class UserStatusServiceImpl implements UserStatusService {
@@ -23,6 +30,7 @@ public class UserStatusServiceImpl implements UserStatusService {
 
     private final UserRepository userRepository;
     private final StatusRepository statusRepository;
+    private final ScheduleRepository scheduleRepository;
 
     private final ProcessService processService;
     private final GradeCalcService gradeCalcService;
@@ -60,15 +68,38 @@ public class UserStatusServiceImpl implements UserStatusService {
     }
 
     @Override
-    public UserPassResponse isPassed() {
+    public UserPassResponse isPassedFirst() {
         Integer receiptCode = authFacade.getReceiptCode();
+
+        Schedule schedule = scheduleRepository.findById("first_notice")
+                .orElseThrow(ScheduleNotFoundException::new);
+
+        if(LocalDateTime.now().compareTo(schedule.getStartDate()) < 0)
+            throw new NotStartedScheduleException();
 
         Status status = statusRepository.findById(receiptCode)
                 .orElseGet(() -> statusRepository.save(new Status(receiptCode)));
 
         return UserPassResponse.builder()
-                .isPassedFirstApply(status.isPassedFirstApply())
-                .isPassedInterview(status.isPassedInterview())
+                .isPassed(status.isPassedFirstApply())
+                .build();
+    }
+
+    @Override
+    public UserPassResponse isPassedFinal() {
+        Integer receiptCode = authFacade.getReceiptCode();
+
+        Schedule schedule = scheduleRepository.findById("notice")
+                .orElseThrow(ScheduleNotFoundException::new);
+
+        if(LocalDateTime.now().compareTo(schedule.getStartDate()) < 0)
+            throw new NotStartedScheduleException();
+
+        Status status = statusRepository.findById(receiptCode)
+                .orElseGet(() -> statusRepository.save(new Status(receiptCode)));
+
+        return UserPassResponse.builder()
+                .isPassed(status.isPassedInterview())
                 .build();
     }
 

--- a/src/main/java/kr/hs/entrydsm/husky/domain/user/service/status/UserStatusServiceImpl.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/user/service/status/UserStatusServiceImpl.java
@@ -3,6 +3,7 @@ package kr.hs.entrydsm.husky.domain.user.service.status;
 import kr.hs.entrydsm.husky.domain.application.domain.CalculatedScore;
 import kr.hs.entrydsm.husky.domain.grade.service.GradeCalcService;
 import kr.hs.entrydsm.husky.domain.process.service.ProcessService;
+import kr.hs.entrydsm.husky.domain.user.dto.UserPassResponse;
 import kr.hs.entrydsm.husky.domain.user.dto.UserStatusResponse;
 import kr.hs.entrydsm.husky.domain.user.exception.NotCompletedProcessException;
 import kr.hs.entrydsm.husky.domain.user.exception.UserNotFoundException;
@@ -56,6 +57,19 @@ public class UserStatusServiceImpl implements UserStatusService {
         statusRepository.save(status);
 
         return UserStatusResponse.response(user, status);
+    }
+
+    @Override
+    public UserPassResponse isPassed() {
+        Integer receiptCode = authFacade.getReceiptCode();
+
+        Status status = statusRepository.findById(receiptCode)
+                .orElseGet(() -> statusRepository.save(new Status(receiptCode)));
+
+        return UserPassResponse.builder()
+                .isPassedFirstApply(status.isPassedFirstApply())
+                .isPassedInterview(status.isPassedInterview())
+                .build();
     }
 
 }

--- a/src/main/java/kr/hs/entrydsm/husky/domain/user/service/status/UserStatusServiceImpl.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/user/service/status/UserStatusServiceImpl.java
@@ -25,6 +25,9 @@ import java.time.LocalDateTime;
 @Service
 public class UserStatusServiceImpl implements UserStatusService {
 
+    private static final String FIRST = "first_notice";
+    private static final String FINAL = "notice";
+
     private final AuthenticationFacade authFacade;
 
     private final UserRepository userRepository;
@@ -70,7 +73,7 @@ public class UserStatusServiceImpl implements UserStatusService {
     public UserPassResponse isPassedFirst() {
         Integer receiptCode = authFacade.getReceiptCode();
 
-        checkSchedule("first_notice");
+        checkSchedule(FIRST);
 
         Status status = statusRepository.findById(receiptCode)
                 .orElseGet(() -> statusRepository.save(new Status(receiptCode)));
@@ -84,7 +87,7 @@ public class UserStatusServiceImpl implements UserStatusService {
     public UserPassResponse isPassedFinal() {
         Integer receiptCode = authFacade.getReceiptCode();
 
-        checkSchedule("notice");
+        checkSchedule(FINAL);
 
         Status status = statusRepository.findById(receiptCode)
                 .orElseGet(() -> statusRepository.save(new Status(receiptCode)));

--- a/src/main/java/kr/hs/entrydsm/husky/global/error/exception/ErrorCode.java
+++ b/src/main/java/kr/hs/entrydsm/husky/global/error/exception/ErrorCode.java
@@ -26,7 +26,9 @@ public enum ErrorCode {
     //Info
     NOT_ADMIN_FORBIDDEN(403, "I403-0", "The server understood the request but refuses to authorize it."),
     APPLICATION_TYPE_UNMATCHED(403, "I403-1", "Application Type is unmatched"),
+    NOT_STARTED_SCHEDULE(403, "I403-2", "Schedule did not start."),
     APPLICATION_NOT_FOUND(404, "I404-0", "Application Not Found"),
+    SCHEDULE_NOT_FOUND(404, "I404-1", "Schedule Not Found"),
     GRADE_TYPE_REQUIRED(406, "I406-0", "Grade type is not set."),
     NOT_COMPLETED_PROCESS(406, "I406-1", "Apply process did not complete yet."),
 

--- a/src/main/java/kr/hs/entrydsm/husky/global/error/exception/ErrorCode.java
+++ b/src/main/java/kr/hs/entrydsm/husky/global/error/exception/ErrorCode.java
@@ -26,11 +26,11 @@ public enum ErrorCode {
     //Info
     NOT_ADMIN_FORBIDDEN(403, "I403-0", "The server understood the request but refuses to authorize it."),
     APPLICATION_TYPE_UNMATCHED(403, "I403-1", "Application Type is unmatched"),
-    NOT_STARTED_SCHEDULE(403, "I403-2", "Schedule did not start."),
+    SCHEDULE_NOT_STARTED(403, "I403-2", "Schedule did not start."),
     APPLICATION_NOT_FOUND(404, "I404-0", "Application Not Found"),
     SCHEDULE_NOT_FOUND(404, "I404-1", "Schedule Not Found"),
     GRADE_TYPE_REQUIRED(406, "I406-0", "Grade type is not set."),
-    NOT_COMPLETED_PROCESS(406, "I406-1", "Apply process did not complete yet."),
+    PROCESS_NOT_COMPLETED(406, "I406-1", "Apply process did not complete yet."),
 
     //School
     SCHOOL_NOT_FOUND(404, "S404-0", "School Not Found."),

--- a/src/main/java/kr/hs/entrydsm/husky/global/util/Validator.java
+++ b/src/main/java/kr/hs/entrydsm/husky/global/util/Validator.java
@@ -24,7 +24,7 @@ public class Validator {
     }
 
     public static boolean isZero(BigDecimal target) {
-        return (target != null) && (target.equals(BigDecimal.ZERO));
+        return (target != null) && (target.compareTo(BigDecimal.ZERO) == 0);
     }
 
 }


### PR DESCRIPTION
# GET Status API 분리
## 목적
### 요약
* GET Status API 분리(마이페이지, 합격여부)
* Validator::isZero(BigDecimal) 검증 기준 수정
### 상세
**GET Status API 분리(마이페이지, 합격여부)**
기존의 `GET/users/me/status` API는 마이페이지에서 사용되는 상태 정보와 합격 확인 페이지에서 사용되는 합격 여부가 모두 포함되어 있었다. 하지만 마이페이지에서 개발자 도구를 이용하여 합격 날짜 전에 미리 합격 여부를 확인할 수 있다는 결함이 있어서 두 개의 API로 분리했다.
* `GET/users/me/status` : 마이페이지 상태 정보 반환 API
* `GET/users/me/status/pass` : 합격여부 반환 API
* `Validator::isZero(BigDecimal)`에서 파라미터의 BigDecimal 값이 0과 동일한지 비교하는 식에 `.equals()` 메서드를 호출하여 소수점이 일치하지 않아 검정고시자가 최종제출이 되지 않는 버그가 있었다. 이에 .equals 대신에 `.compare()` 메서드로 대체하여 이를 수정했다.
## 영향을 미치는 부분
API Docs(업데이트 완료), 프론트엔드 합격여부 페이지 사용 API 변경(프론트 팀에게 전달 필요)
## 참조(선택)
#76 해결 
