### PR TITLE
[FIX] 마이스터 전형 선택시 학교장 추천서에 중복 표기되는 오류 수정

### DIFF
--- a/src/main/java/kr/hs/entrydsm/husky/domain/pdf/converter/ApplicationInfoConverter.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/pdf/converter/ApplicationInfoConverter.java
@@ -201,7 +201,7 @@ public class ApplicationInfoConverter {
         values.put("isDaejeonAndMeister", markOIfTrue(user.getIsDaejeon() && user.isMeisterApplyType()));
         values.put("isDaejeonAndSocialMerit", markOIfTrue(user.getIsDaejeon() && user.isSocialMeritApplytype()));
         values.put("isNotDaejeonAndMeister", markOIfTrue(!user.getIsDaejeon() && user.isMeisterApplyType()));
-        values.put("isNotDaejeonAndSocialMerit", markOIfTrue(!user.getIsDaejeon() && user.isMeisterApplyType()));
+        values.put("isNotDaejeonAndSocialMerit", markOIfTrue(!user.getIsDaejeon() && user.isSocialMeritApplytype()));
     }
 
     private String markOIfTrue(boolean isTrue) {

--- a/src/main/java/kr/hs/entrydsm/husky/domain/pdf/converter/ApplicationInfoConverter.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/pdf/converter/ApplicationInfoConverter.java
@@ -168,7 +168,7 @@ public class ApplicationInfoConverter {
         values.put("isPrivilegedAdmission", toBallotBox(user.isAdditionalTypeEquals(PRIVILEGED_ADMISSION)));
         values.put("isCommon", toBallotBox(user.isCommonApplyType()));
         values.put("isMeister", toBallotBox(user.isMeisterApplyType()));
-        values.put("isSocialMerit", toBallotBox(user.isSocialMeritApplytype()));
+        values.put("isSocialMerit", toBallotBox(user.isSocialMeritApplyType()));
     }
 
     private void setGradeScore(Map<String, Object> values, User user, CalculatedScore calculatedScore) {
@@ -199,9 +199,9 @@ public class ApplicationInfoConverter {
 
     private void setRecommendations(Map<String, Object> values, User user) {
         values.put("isDaejeonAndMeister", markOIfTrue(user.getIsDaejeon() && user.isMeisterApplyType()));
-        values.put("isDaejeonAndSocialMerit", markOIfTrue(user.getIsDaejeon() && user.isSocialMeritApplytype()));
+        values.put("isDaejeonAndSocialMerit", markOIfTrue(user.getIsDaejeon() && user.isSocialMeritApplyType()));
         values.put("isNotDaejeonAndMeister", markOIfTrue(!user.getIsDaejeon() && user.isMeisterApplyType()));
-        values.put("isNotDaejeonAndSocialMerit", markOIfTrue(!user.getIsDaejeon() && user.isSocialMeritApplytype()));
+        values.put("isNotDaejeonAndSocialMerit", markOIfTrue(!user.getIsDaejeon() && user.isSocialMeritApplyType()));
     }
 
     private String markOIfTrue(boolean isTrue) {

--- a/src/main/java/kr/hs/entrydsm/husky/domain/user/domain/User.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/user/domain/User.java
@@ -179,7 +179,7 @@ public class User extends BaseTimeEntity {
         return !isApplyTypeEmpty() && applyType.equals(MEISTER);
     }
 
-    public boolean isSocialMeritApplytype() {
+    public boolean isSocialMeritApplyType() {
         return !isCommonApplyType() && !isMeisterApplyType();
     }
 


### PR DESCRIPTION
# [FIX] 마이스터 전형 선택시 학교장 추천서에 중복 표기되는 오류 수정
## 목적
### 요약
마이스터 전형 선택시 학교장 추천서에 중복 표기되는 버그를 수정했습니다.
### 상세
- `isNotDaejeonAndSocialMerit` 필드의 조건식에 `isSocialMeritApplyType`가 아닌 `isMeisterApplyType`이 지정되어 있음을 확인하고 이를 수정했습니다.
- 메서드 이름에 오타가 있는 것을 발견하여 이를 수정했습니다.