### PR TITLE
템플릿/폰트 파일명 상수화

### DIFF
--- a/src/main/java/kr/hs/entrydsm/husky/domain/pdf/config/PdfConfig.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/pdf/config/PdfConfig.java
@@ -5,6 +5,7 @@ import com.itextpdf.html2pdf.resolver.font.DefaultFontProvider;
 import com.itextpdf.io.font.FontProgram;
 import com.itextpdf.io.font.FontProgramFactory;
 import com.itextpdf.layout.font.FontProvider;
+import kr.hs.entrydsm.husky.domain.pdf.constant.Font;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -36,10 +37,10 @@ public class PdfConfig {
         FontProvider fontProvider = new DefaultFontProvider(false, false, false);
 
         List.of(
-                "/fonts/KoPubWorld_Dotum_Light.ttf",
-                "/fonts/KoPubWorld_Dotum_Bold.ttf",
-                "/fonts/KoPubWorld_Dotum_Medium.ttf",
-                "/fonts/DejaVuSans.ttf")
+                Font.KO_PUB_WORLD_DOTUM_LIGHT,
+                Font.KO_PUB_WORLD_DOTUM_BOLD,
+                Font.KO_PUB_WORLD_DOTUM_MEDIUM,
+                Font.DEJA_VU_SANS)
                 .forEach(font -> {
                     try {
                         FontProgram fontProgram = FontProgramFactory.createFont(font);

--- a/src/main/java/kr/hs/entrydsm/husky/domain/pdf/constant/Font.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/pdf/constant/Font.java
@@ -1,0 +1,11 @@
+package kr.hs.entrydsm.husky.domain.pdf.constant;
+
+public class Font {
+
+    public static final String KO_PUB_WORLD_DOTUM_LIGHT = "/fonts/KoPubWorld_Dotum_Light.ttf";
+    public static final String KO_PUB_WORLD_DOTUM_BOLD = "/fonts/KoPubWorld_Dotum_Bold.ttf";
+    public static final String KO_PUB_WORLD_DOTUM_MEDIUM = "/fonts/KoPubWorld_Dotum_Medium.ttf";
+
+    public static final String DEJA_VU_SANS = "/fonts/DejaVuSans.ttf";
+
+}

--- a/src/main/java/kr/hs/entrydsm/husky/domain/pdf/constant/TemplateFileName.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/pdf/constant/TemplateFileName.java
@@ -1,0 +1,9 @@
+package kr.hs.entrydsm.husky.domain.pdf.constant;
+
+public class TemplateFileName {
+    public static final String APPLICATION_FOR_ADMISSION = "/application_for_admission";
+    public static final String INTRODUCTION = "/introduction";
+    public static final String NON_SMOKING = "/nonsmoking";
+    public static final String RECOMMENDATION = "/recommendation";
+    public static final String ADMISSION_AGREEMENT = "/admission_agreement";
+}

--- a/src/main/java/kr/hs/entrydsm/husky/domain/pdf/constant/TemplateFileName.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/pdf/constant/TemplateFileName.java
@@ -1,9 +1,11 @@
 package kr.hs.entrydsm.husky.domain.pdf.constant;
 
 public class TemplateFileName {
+
     public static final String APPLICATION_FOR_ADMISSION = "/application_for_admission";
     public static final String INTRODUCTION = "/introduction";
     public static final String NON_SMOKING = "/nonsmoking";
     public static final String RECOMMENDATION = "/recommendation";
     public static final String ADMISSION_AGREEMENT = "/admission_agreement";
+
 }

--- a/src/main/java/kr/hs/entrydsm/husky/domain/pdf/service/PDFExportServiceImpl.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/pdf/service/PDFExportServiceImpl.java
@@ -3,6 +3,7 @@ package kr.hs.entrydsm.husky.domain.pdf.service;
 import kr.hs.entrydsm.husky.domain.application.domain.CalculatedScore;
 import kr.hs.entrydsm.husky.domain.grade.exception.UserNotFoundException;
 import kr.hs.entrydsm.husky.domain.grade.service.GradeCalcService;
+import kr.hs.entrydsm.husky.domain.pdf.constant.TemplateFileName;
 import kr.hs.entrydsm.husky.domain.pdf.converter.ApplicationInfoConverter;
 import kr.hs.entrydsm.husky.domain.pdf.converter.HtmlConverter;
 import kr.hs.entrydsm.husky.domain.pdf.exception.FinalSubmitRequiredException;
@@ -64,13 +65,13 @@ public class PDFExportServiceImpl implements PDFExportService {
             Map<String, Object> data = applicationInfoConverter.applicationToInfo(user, calculatedScore);
 
             List<String> templates = new LinkedList<>(List.of(
-                    "/application_for_admission",
-                    "/introduction",
-                    "/nonsmoking",
-                    "/admission_agreement"));
+                    TemplateFileName.APPLICATION_FOR_ADMISSION,
+                    TemplateFileName.INTRODUCTION,
+                    TemplateFileName.NON_SMOKING,
+                    TemplateFileName.ADMISSION_AGREEMENT));
 
             if (!user.isGED() && !user.isCommonApplyType())
-                templates.add(2, "/recommendation");
+                templates.add(2, TemplateFileName.RECOMMENDATION);
 
             ByteArrayOutputStream result = templates.parallelStream()
                     .map(template -> templateProcessor.process(template, data))


### PR DESCRIPTION
# 템플릿/폰트 파일명 상수화
## 목적
### 요약
코드 내 하드코딩 되어 있던 템플릿/폰트의 파일 경로를 별도의 클래스를 만들어 static 상수로 변경하였습니다.

### 상세
- pdf.constant.Font, pdf.constant.TemplateFileName 클래스 추가
- 각 파일 경로를 static final const로 선언