### PR TITLE
[FIX] 자기소개서/학업소개서 입력 칸 개행 적용

### DIFF
--- a/src/main/java/kr/hs/entrydsm/husky/domain/pdf/converter/ApplicationInfoConverter.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/pdf/converter/ApplicationInfoConverter.java
@@ -191,6 +191,7 @@ public class ApplicationInfoConverter {
     private void setIntroduction(Map<String, Object> values, User user) {
         values.put("selfIntroduction", setBlankIfNull(user.getSelfIntroduction()));
         values.put("studyPlan", setBlankIfNull(user.getStudyPlan()));
+        values.put("newLineChar", "\n");
     }
 
     private void setParentInfo(Map<String, Object> values, User user) {

--- a/src/main/resources/templates/introduction.html
+++ b/src/main/resources/templates/introduction.html
@@ -56,8 +56,7 @@
         </td>
     </tr>
     <tr>
-        <td style=" min-height: 230px;text-align: left;"><p style="min-height: 230px;"
-                                                            th:text="${selfIntroduction}"></p></td>
+        <td style=" min-height: 230px;text-align: left;"><p style="min-height: 230px;" th:utext="${#strings.replace(selfIntroduction, newLineChar, '&lt;br /&gt;')}"></p></td>
     </tr>
 </table>
 <table style="margin-bottom: 50px;">
@@ -67,7 +66,7 @@
         </td>
     </tr>
     <tr>
-        <td style=" min-height: 230px;text-align: left;"><p style="min-height: 230px" th:text="${studyPlan}"></p></td>
+        <td style=" min-height: 230px;text-align: left;"><p style="min-height: 230px" th:utext="${#strings.replace(studyPlan, newLineChar, '&lt;br /&gt;')}"></p></td>
     </tr>
 </table>
 </div>


### PR DESCRIPTION
# [FIX] 자기소개서/학업소개서 입력 칸 개행 적용
## 목적
### 요약
자기소개서/학업소개서 필드 개행 적용

### 상세
자기소개서 및 학업소개서 입력 칸에 개행이 적용되지 않는 버그가 있어 이를 수정했습니다.
html에서 `\n`을 인식하지 못해 발생한 문제로, `\n`을 `<br />`로 대체하는 로직을 추가했습니다.