### PR TITLE
FIX: 원서출력 시 성별이 null인 경우 NullPointerException 발생

### DIFF
--- a/src/main/java/kr/hs/entrydsm/husky/domain/pdf/converter/ApplicationInfoConverter.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/pdf/converter/ApplicationInfoConverter.java
@@ -37,6 +37,7 @@ public class ApplicationInfoConverter {
         Map<String, Object> values = new HashMap<>();
         setReceiptCode(values, user);
         setPersonalInfo(values, user);
+        setGenderInfo(values, user);
         setSchoolInfo(values, user);
         setPhoneNumber(values, user);
         setGraduationClassification(values, user);
@@ -72,19 +73,14 @@ public class ApplicationInfoConverter {
             birthDate = user.getBirthDate().format(formatter);
         }
         values.put("birthDate", birthDate);
+    }
 
-        String gender;
-        switch (user.getSex()) {
-            case FEMALE:
-                gender = "여";
-                break;
-
-            case MALE:
-                gender = "남";
-                break;
-
-            default:
-                gender = null;
+    private void setGenderInfo(Map<String, Object> values, User user) {
+        String gender = null;
+        if (user.isFemale()) {
+            gender = "여";
+        } else if (user.isMale()) {
+            gender = "남";
         }
         values.put("gender", setBlankIfNull(gender));
     }

--- a/src/main/java/kr/hs/entrydsm/husky/domain/pdf/converter/ApplicationInfoConverter.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/pdf/converter/ApplicationInfoConverter.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Base64;
@@ -207,7 +208,7 @@ public class ApplicationInfoConverter {
 
     private void setBase64Image(Map<String, Object> values, User user) throws IOException {
         byte[] image = imageService.getObject(user.getUserPhoto());
-        String base64EncodedImage = new String(Base64.getEncoder().encode(image), "UTF-8");
+        String base64EncodedImage = new String(Base64.getEncoder().encode(image), StandardCharsets.UTF_8);
         values.put("base64Image", base64EncodedImage);
     }
 

--- a/src/main/java/kr/hs/entrydsm/husky/domain/user/domain/User.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/user/domain/User.java
@@ -148,11 +148,11 @@ public class User extends BaseTimeEntity {
     }
 
     public boolean isMale() {
-        return this.sex.equals(Sex.MALE);
+        return isGenderExists() && this.sex.equals(Sex.MALE);
     }
 
     public boolean isFemale() {
-        return this.sex.equals(Sex.FEMALE);
+        return isGenderExists() && this.sex.equals(Sex.FEMALE);
     }
 
     public boolean isGradeTypeEmpty() {

--- a/src/main/java/kr/hs/entrydsm/husky/domain/user/domain/User.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/user/domain/User.java
@@ -143,6 +143,10 @@ public class User extends BaseTimeEntity {
                 userPhoto != null;
     }
 
+    public boolean isGenderExists() {
+        return this.sex != null;
+    }
+
     public boolean isMale() {
         return this.sex.equals(Sex.MALE);
     }

--- a/src/main/java/kr/hs/entrydsm/husky/global/util/Validator.java
+++ b/src/main/java/kr/hs/entrydsm/husky/global/util/Validator.java
@@ -3,6 +3,7 @@ package kr.hs.entrydsm.husky.global.util;
 import java.math.BigDecimal;
 
 public class Validator {
+
     public static boolean isExists(String target) {
         return (target != null) && (!target.isBlank());
     }


### PR DESCRIPTION
# FIX: 원서출력 시 성별이 null인 경우 NullPointerException 발생
## 목적
### 요약
원서출력 시 성별의 값이 null인 경우 NullPointerException이 발생하는 것을 수정했습니다.

### 상세
- User#isFemale, User#isMale 메서드에서 User#isGenderExists 메서드의 반환값을 참조하도록 변경했습니다.
- ApplicationInfoConverter 내 성별 기입 로직을 ApplicationInfoConverter#setGenderInfo로 분리했습니다.
