### PR TITLE
[DELETE] PDF 출력 대상에서 입학동의서 삭제

### DIFF
--- a/src/main/java/kr/hs/entrydsm/husky/domain/pdf/service/PDFExportServiceImpl.java
+++ b/src/main/java/kr/hs/entrydsm/husky/domain/pdf/service/PDFExportServiceImpl.java
@@ -67,8 +67,9 @@ public class PDFExportServiceImpl implements PDFExportService {
             List<String> templates = new LinkedList<>(List.of(
                     TemplateFileName.APPLICATION_FOR_ADMISSION,
                     TemplateFileName.INTRODUCTION,
-                    TemplateFileName.NON_SMOKING,
-                    TemplateFileName.ADMISSION_AGREEMENT));
+                    TemplateFileName.NON_SMOKING
+//                    TemplateFileName.ADMISSION_AGREEMENT));
+                    ));
 
             if (!user.isGED() && !user.isCommonApplyType())
                 templates.add(2, TemplateFileName.RECOMMENDATION);


### PR DESCRIPTION
# PDF 출력 대상에서 입학동의서 삭제
## 목적
### 요약
선생님의 요청으로 PDF 출력 대상에서 입학동의서를 제외합니다.

### 상세
- template 목록에서 입학동의서를 주석 처리합니다.